### PR TITLE
Fix tests so node name are always interpreted as strings

### DIFF
--- a/tests/st/bgp/peer.py
+++ b/tests/st/bgp/peer.py
@@ -29,7 +29,7 @@ def create_bgp_peer(host, scope, ip, asNum, metadata=None):
     # Add optional params
     # If node is not specified, scope is global.
     if scope == "node":
-        testdata['spec']['node'] = host.get_hostname()
+        testdata['spec']['node'] = '%s' % host.get_hostname()
     if metadata is not None:
         testdata['metadata'] = metadata
 

--- a/tests/st/config/test_felix_config.py
+++ b/tests/st/config/test_felix_config.py
@@ -372,7 +372,7 @@ class TestFelixConfig(TestBase):
                 'labels': {'nodeEth': 'host'}
             },
             'spec': {
-                'node': node_name,
+                'node': '%s' % node_name,
                 'interfaceName': 'eth0',
                 'expectedIPs': [str(ip)],
             }

--- a/tests/st/policy/test_felix_gateway.py
+++ b/tests/st/policy/test_felix_gateway.py
@@ -726,7 +726,7 @@ class TestFelixOnGateway(TestBase):
                 'labels': {'nodeEth': 'gateway-int'}
             },
             'spec': {
-                'node': self.gateway_hostname,
+                'node': '%s' % self.gateway_hostname,
                 'interfaceName': 'eth0'
             }
         }
@@ -741,7 +741,7 @@ class TestFelixOnGateway(TestBase):
                 'labels': {'nodeEth': 'gateway-ext'}
             },
             'spec': {
-                'node': self.gateway_hostname,
+                'node': '%s' % self.gateway_hostname,
                 'interfaceName': 'eth1'
             }
         }
@@ -756,7 +756,7 @@ class TestFelixOnGateway(TestBase):
                 'labels': {'nodeEth': 'host'}
             },
             'spec': {
-                'node': self.host_hostname,
+                'node': '%s' % self.host_hostname,
                 'interfaceName': 'eth0',
                 'expectedIPs': [str(self.host.ip)],
             }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Attempt to fix failures like this one: https://semaphoreci.com/calico/node/branches/master/builds/18

```
CommandExecError: Command docker exec -it cali-st-gw sh -c 'export ETCD_ENDPOINTS=https://etcd-authority-ssl:2379; export ETCD_CA_CERT_FILE=/home/runner/node/certs/ca.pem; export ETCD_CERT_FILE=/home/runner/node/certs/client.pem; export ETCD_KEY_FILE=/home/runner/node/certs/client-key.pem; /code/dist/calicoctl apply -f new_data' failed with RC 1 and output:

Failed to execute command: error with field node = '7.00388428e+15'
```

yaml/json is interpreting some node names as ints because they're not explicitly quoted as strings.  

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
