### PR TITLE
Add CNIVersion to ClusterInformation type

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 12abacddefdbba2dae7d5c22a3991b16bf3089066151acdcd7f0bd6ed81b4dac
-updated: 2018-05-29T19:40:00.842480589Z
+hash: 5d51509ecbe004d43fec2df1835de6f336a5a03ff1d4b0102a3b8d8c1214c15a
+updated: 2018-06-05T17:37:02.6740508Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -17,6 +17,10 @@ imports:
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
+- name: github.com/containernetworking/cni
+  version: 86431d5c16064ec0ce3c215297f5bbf7112fbbde
+  subpackages:
+  - pkg/types
 - name: github.com/coreos/etcd
   version: c23606781f63d09917a1e7abfcefeb337a9608ea
   subpackages:
@@ -33,7 +37,7 @@ imports:
   - pkg/types
   - version
 - name: github.com/coreos/go-semver
-  version: e214231b295a8ea9479f11b70b35d5acf3556d9b
+  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
   subpackages:
   - semver
 - name: github.com/davecgh/go-spew
@@ -144,7 +148,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: 7ac6b01f7d376befdf752224be59eed5d21fab4b
+  version: 62bff4df71bdbc266561a0caee19f0594b17c240
   subpackages:
   - format
   - internal/assertion
@@ -161,6 +165,10 @@ imports:
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
+- name: github.com/projectcalico/cni-plugin
+  version: a9d8b5d2d84e996d6a52bd7af54e82505b4b0cdb
+  subpackages:
+  - types
 - name: github.com/projectcalico/go-json
   version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
   subpackages:
@@ -170,7 +178,8 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: d6aff54dc3527357f016c0cd5c5364f21a15e9b4
+  version: 6685fc9f71ae6e0bb42c2ea6a958abeb036f2cfc
+  repo: https://github.com/dmmcquay/libcalico-go
   subpackages:
   - lib/api
   - lib/apiconfig
@@ -245,7 +254,7 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/crypto
-  version: ab813273cd59e1333f7ae7bff5d027d4aadf528c
+  version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -270,10 +279,9 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: c11f84a56e43e20a78cee75a7c034031ecf57d1f
+  version: ebfc5b4631820b793c9010c87fd8fef0f39eb082
   subpackages:
   - unix
-  - windows
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,8 @@ import:
 - package: github.com/sirupsen/logrus
   version: v1.0.4
 - package: github.com/projectcalico/libcalico-go
-  version: d6aff54dc3527357f016c0cd5c5364f21a15e9b4
+  repo: https://github.com/dmmcquay/libcalico-go
+  version: 6685fc9f71ae6e0bb42c2ea6a958abeb036f2cfc
   subpackages:
   - lib/api
   - lib/client
@@ -19,3 +20,5 @@ import:
   version: f98634e408857669d61064b283c4cde240622865
 - package: golang.org/x/net
   version: 66aacef3dd8a676686c7ae3716979581e8b03c47
+- package: github.com/projectcalico/cni-plugin
+  version: a9d8b5d2d84e996d6a52bd7af54e82505b4b0cdb


### PR DESCRIPTION
## Description

Improve diagnostics by adding CNIVersion to ClusterInformation type.

Related to projectcalico/calicoctl#1826

## Todos
- [ ] Tests
- [ ] Update libcalico-go once [libcalico-go PR](https://github.com/projectcalico/libcalico-go/pull/877) is merged

## Release Note

```release-note
None required
```
