### PR TITLE
Makefile/Dockerfile: Fix up calico/node image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Ignore everything except the filesystem that gets copied in
+*
+!filesystem

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,27 +18,8 @@ MAINTAINER Tom Denham <tom@projectcalico.org>
 ARG ver="n/a"
 ENV NODE_VERSION=$ver
 
-# Set the minimum Docker API version required for libnetwork.
-ENV DOCKER_API_VERSION 1.21
-
-# Set glibc version
-ENV GLIBC_VERSION 2.27-r0
-
-# Download and install glibc for use by non-static binaries that require it.
-RUN apk --no-cache add wget ca-certificates libgcc && \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-bin-$GLIBC_VERSION.apk && \
-    apk add glibc-$GLIBC_VERSION.apk glibc-bin-$GLIBC_VERSION.apk && \
-    /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc/usr/lib && \
-    apk del wget && \
-    rm -f glibc-$GLIBC_VERSION.apk glibc-bin-$GLIBC_VERSION.apk
-
-# Install runit from the community repository, as its not yet available in global
-RUN apk add --no-cache --repository "http://alpine.gliderlabs.com/alpine/edge/community" runit
-
 # Install remaining runtime deps required for felix from the global repository
-RUN apk add --no-cache ip6tables ipset iputils iproute2 conntrack-tools
+RUN apk add --no-cache ip6tables ipset iputils iproute2 conntrack-tools runit
 
 # Copy in the filesystem - this contains felix, bird, calico-bgp-daemon etc...
 COPY filesystem /

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ $(BUILT_BINARIES): vendor
 ###############################################################################
 ## Create the calico/node image.
 image: $(NODE_CONTAINER_NAME)
-calico/node: $(NODE_CONTAINER_NAME)
 $(NODE_CONTAINER_NAME): $(NODE_CONTAINER_CREATED)
 $(NODE_CONTAINER_CREATED): ./Dockerfile$(ARCHTAG) $(NODE_CONTAINER_FILES) $(addprefix $(NODE_CONTAINER_BIN_DIR)/,$(NODE_CONTAINER_BINARIES))
 	# Check versions of the binaries that we're going to use to build calico/node.


### PR DESCRIPTION
```release-note
calico/node image no longer contains glibc
```

Image:
  Stop adding glibc (not used anymore)
  Stop using edge for runit

Add a Dockerignore file to ignore everything exept the filesystem
directory

Fix up a circular import in the Makefile