### PR TITLE
Build a single calico-node binary by importing code

### DIFF
--- a/cmd/calico-node/main.go
+++ b/cmd/calico-node/main.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	confdConfig "github.com/kelseyhightower/confd/pkg/config"
+	confd "github.com/kelseyhightower/confd/pkg/run"
+	felix "github.com/projectcalico/felix/daemon"
+
+	"github.com/projectcalico/node/pkg/allocateipip"
+	"github.com/projectcalico/node/pkg/readiness"
+	"github.com/projectcalico/node/pkg/startup"
+
+	"github.com/projectcalico/libcalico-go/lib/logutils"
+	"github.com/sirupsen/logrus"
+)
+
+// Populated by build - used for printing version.
+var VERSION string
+
+// Create a new flag set.
+var flagSet = flag.NewFlagSet("Calico", flag.ContinueOnError)
+
+// Build the set of supported flags.
+var version = flagSet.Bool("v", false, "Display version")
+var runFelix = flagSet.Bool("felix", false, "Run Felix")
+var runStartup = flagSet.Bool("startup", false, "Initialize a new node")
+var runAllocateIPIP = flagSet.Bool("allocate-ipip-addr", false, "Allocate an IPIP address for this node")
+
+// Options for readiness checks.
+var birdReady = flagSet.Bool("bird-ready", false, "Run BIRD readiness checks")
+var bird6Ready = flagSet.Bool("bird6-ready", false, "Run BIRD6 readiness checks")
+var felixReady = flagSet.Bool("felix-ready", false, "Run felix readiness checks")
+
+// confd flags
+var runConfd = flagSet.Bool("confd", false, "Run confd")
+var confdRunOnce = flagSet.Bool("confd-run-once", false, "Run confd in oneshot mode")
+var confdKeep = flagSet.Bool("confd-keep-stage-file", false, "Keep stage file when running confd")
+
+func main() {
+	// Set up logging formatting.
+	logrus.SetFormatter(&logutils.Formatter{})
+
+	// Install a hook that adds file/line no information.
+	logrus.AddHook(&logutils.ContextHook{})
+
+	// Parse the provided flags.
+	err := flagSet.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Perform some validation on the parsed flags. Only one of the following may be
+	// specified at a time.
+	onlyOne := []*bool{version, runFelix, runStartup, runConfd}
+	oneSelected := false
+	for _, o := range onlyOne {
+		if oneSelected && *o {
+			fmt.Println("More than one incompatible argument provided")
+			os.Exit(1)
+		}
+
+		if *o {
+			oneSelected = true
+		}
+	}
+
+	// If any of the readienss options are provided, check readiness.
+	if *birdReady || *bird6Ready || *felixReady {
+		readiness.Run(*birdReady, *bird6Ready, *felixReady)
+		os.Exit(0)
+	}
+
+	// Decide which action to take based on the given flags.
+	if *version {
+		fmt.Println(VERSION)
+		os.Exit(0)
+	} else if *runFelix {
+		felix.Run("/etc/calico/felix.cfg")
+	} else if *runStartup {
+		startup.Run()
+	} else if *runConfd {
+		cfg, err := confdConfig.InitConfig(true)
+		cfg.ConfDir = "/etc/calico/confd"
+		cfg.KeepStageFile = *confdKeep
+		cfg.Onetime = *confdRunOnce
+		if err != nil {
+			panic(err)
+		}
+		confd.Run(cfg)
+	} else if *runAllocateIPIP {
+		allocateipip.Run()
+	} else {
+		fmt.Println("No valid options provided. Usage:")
+		flagSet.PrintDefaults()
+		os.Exit(1)
+	}
+}

--- a/filesystem/etc/calico/confd/conf.d/tunl-ip.toml
+++ b/filesystem/etc/calico/confd/conf.d/tunl-ip.toml
@@ -5,4 +5,4 @@ prefix = "/calico/v1/ipam/v4"
 keys = [
     "/pool",
 ]
-reload_cmd = "allocate-ipip-addr"
+reload_cmd = "calico-node -allocate-ipip-addr"

--- a/filesystem/etc/calico/confd/templates/tunl-ip.template
+++ b/filesystem/etc/calico/confd/templates/tunl-ip.template
@@ -1,6 +1,5 @@
-We must dump all pool data to this file to trigger a resync.
-Otherwise, confd notices the file hasn't changed and won't
-run our python update script.
+We must dump all pool data to this file to trigger a re-run of the IPIP tunnel
+address allocation code whenever an IP pool changes.
  
 {{range ls "/pool"}}{{$data := json (getv (printf "/pool/%s" .))}}
   {{if $data.ipip}}{{if not $data.disabled}}{{$data.cidr}}{{end}}{{end}}

--- a/filesystem/etc/rc.local
+++ b/filesystem/etc/rc.local
@@ -10,9 +10,9 @@ fi
 
 # Run the startup initialisation script.  These ensure the node is correctly
 # configured to run.
-startup || exit 1
+calico-node -startup || exit 1
 
-# Set the nodename based on the value picked by the startup binary.
+# Set the nodename based on the value picked by the startup procedure.
 if [ ! -f "/var/lib/calico/nodename" ]; then
 	echo "/var/lib/calico/nodename does not exist, exiting"
 	exit 1
@@ -20,7 +20,7 @@ fi
 export NODENAME=$(cat /var/lib/calico/nodename)
 
 # If possible pre-allocate the IP address on the IPIP tunnel.
-allocate-ipip-addr || exit 1
+calico-node -allocate-ipip-addr || exit 1
 
 # Create a directly to put enabled service files
 mkdir /etc/service/enabled
@@ -61,7 +61,7 @@ case "$CALICO_NETWORKING_BACKEND" in
 
 	# Run confd once - this ensures we have sensible config generated at the point we start
 	# bird.
-    confd -confdir=/etc/calico/confd -onetime -keep-stage-file >/felix-startup-1.log 2>&1 || true
+	calico-node -confd -confd-onetime -confd-keep-stage-file >/felix-startup-1.log 2>&1 || true
 
 	# Enable the confd and bird services
 	cp -a /etc/service/available/bird  /etc/service/enabled/

--- a/filesystem/etc/service/available/confd/run
+++ b/filesystem/etc/service/available/confd/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec confd -confdir=/etc/calico/confd 
+exec calico-node -confd

--- a/filesystem/etc/service/available/felix/run
+++ b/filesystem/etc/service/available/felix/run
@@ -15,4 +15,4 @@ export FELIX_ETCDCERTFILE=$ETCD_CERT_FILE
 if [ ! -z $DATASTORE_TYPE ]; then
     export FELIX_DATASTORETYPE=$DATASTORE_TYPE
 fi
-exec calico-felix
+exec calico-node -felix 

--- a/filesystem/sbin/start_runit
+++ b/filesystem/sbin/start_runit
@@ -10,7 +10,7 @@ then
     exit $retval
 fi
 
-# Export the nodename set by the startup script. 
+# Export the nodename set by the startup procedure. 
 export NODENAME=$(cat /var/lib/calico/nodename)
 
 exec /sbin/runsvdir -P /etc/service/enabled

--- a/filesystem/sbin/versions
+++ b/filesystem/sbin/versions
@@ -1,11 +1,7 @@
 #!/bin/sh
 echo calico/node ${NODE_VERSION}
-confd -version
-bird --version
-echo -n "libnetwork-plugin: "
-libnetwork-plugin -v
-echo -n "calico-bgp-daemon: "
-calico-bgp-daemon -v
+calico-node -v 
+
 echo ""
-echo "Felix:"
-calico-felix --version
+bird --version
+echo ""

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 12abacddefdbba2dae7d5c22a3991b16bf3089066151acdcd7f0bd6ed81b4dac
-updated: 2018-05-29T19:40:00.842480589Z
+hash: 9c5732fda59386b8d7cf5e930362dd8f4f8e7e8936963dab1625dcd3319b0321
+updated: 2018-07-09T17:39:58.272247845-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -17,6 +17,8 @@ imports:
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
+- name: github.com/BurntSushi/toml
+  version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
 - name: github.com/coreos/etcd
   version: c23606781f63d09917a1e7abfcefeb337a9608ea
   subpackages:
@@ -41,15 +43,17 @@ imports:
   subpackages:
   - spew
 - name: github.com/dgrijalva/jwt-go
-  version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
+  version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/emicklei/go-restful
-  version: ff4f55a206334ef123e4f79bbf348980da81ca46
+  version: 777bb3f19bcafe2575ffb2a3e46af92509ae9594
   subpackages:
   - log
 - name: github.com/emicklei/go-restful-swagger12
   version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
+- name: github.com/go-ini/ini
+  version: 06f5f3d67269ccec1fe5fe4134ba6e982984f7f5
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -59,7 +63,7 @@ imports:
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
-  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
   - gogoproto
   - proto
@@ -76,11 +80,11 @@ imports:
   - ptypes/duration
   - ptypes/timestamp
 - name: github.com/google/btree
-  version: 925471ac9e2131377a91e1595defec898166fe49
+  version: 7d79101e329e5a3adf994758c578dab82b90c017
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/googleapis/gnostic
-  version: 68f4ded48ba9414dab2ae69b3f0d69971da73aa5
+  version: 0c5108395e2debce0d731cf0287ddf7242066aba
   subpackages:
   - OpenAPIv2
   - compiler
@@ -107,11 +111,25 @@ imports:
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/json-iterator/go
-  version: 36b14963da70d11297d313183d7e6388c8510e1e
+  version: f2b4162afba35581b6d4a50d3b8f34e33c144682
 - name: github.com/juju/ratelimit
   version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
+- name: github.com/kardianos/osext
+  version: ae77be60afb1dcacde03767a8c37337fad28ac14
+- name: github.com/kelseyhightower/confd
+  version: 1eb2608e4dea19483ff0bdb260b63c09bd15bf98
+  repo: https://github.com/projectcalico/confd.git
+  subpackages:
+  - pkg/backends
+  - pkg/backends/calico
+  - pkg/config
+  - pkg/log
+  - pkg/resource/template
+  - pkg/run
 - name: github.com/kelseyhightower/envconfig
   version: f611eb38b3875cc3bd991ca91c51d06446afa14c
+- name: github.com/kelseyhightower/memkv
+  version: 892bfd468afa0fa476556e7bd7734a087cda08b3
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -122,6 +140,16 @@ imports:
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
+- name: github.com/Microsoft/go-winio
+  version: 78439966b38d69bf38227fbf57ac8a6fee70f69a
+- name: github.com/Microsoft/hcsshim
+  version: 34a629f78a5d50f7de07727e41a948685c45e026
+- name: github.com/mipearson/rfw
+  version: 6f0a6f3266ba1058df9ef0c94cda1cecd2e62852
+- name: github.com/modern-go/concurrent
+  version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
+- name: github.com/modern-go/reflect2
+  version: 05fbef0ca5da472bbf96c9322b84a53edc03c9fd
 - name: github.com/onsi/ginkgo
   version: fa5fabab2a1bfbd924faf4c067d07ae414e2aedf
   subpackages:
@@ -144,7 +172,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: 7ac6b01f7d376befdf752224be59eed5d21fab4b
+  version: 62bff4df71bdbc266561a0caee19f0594b17c240
   subpackages:
   - format
   - internal/assertion
@@ -161,6 +189,40 @@ imports:
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
+- name: github.com/projectcalico/felix
+  version: e0ce0bca201da59671dd166e80a9c96f2bca6201
+  subpackages:
+  - binder
+  - buildinfo
+  - calc
+  - config
+  - conntrack
+  - daemon
+  - dataplane
+  - dataplane/external
+  - dataplane/linux
+  - dataplane/windows
+  - dataplane/windows/ipsets
+  - dataplane/windows/policysets
+  - dispatcher
+  - hashutils
+  - ifacemonitor
+  - ip
+  - ipsets
+  - iptables
+  - jitter
+  - labelindex
+  - logutils
+  - markbits
+  - multidict
+  - policysync
+  - proto
+  - routetable
+  - rules
+  - statusrep
+  - stringutils
+  - throttle
+  - usagerep
 - name: github.com/projectcalico/go-json
   version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
   subpackages:
@@ -184,10 +246,15 @@ imports:
   - lib/backend/k8s/conversion
   - lib/backend/k8s/resources
   - lib/backend/model
+  - lib/backend/syncersv1/bgpsyncer
+  - lib/backend/syncersv1/felixsyncer
+  - lib/backend/syncersv1/updateprocessors
+  - lib/backend/watchersyncer
   - lib/client
   - lib/clientv3
   - lib/errors
   - lib/hash
+  - lib/health
   - lib/ipam
   - lib/ipip
   - lib/logutils
@@ -210,12 +277,20 @@ imports:
   - lib/upgrade/migrator/clients/v1/k8s
   - lib/upgrade/migrator/clients/v1/k8s/custom
   - lib/upgrade/migrator/clients/v1/k8s/resources
+  - lib/validator/v1
   - lib/validator/v3
   - lib/watch
+- name: github.com/projectcalico/typha
+  version: 5ef90ad5dd6d0d6a12ecb736d8f813b4b7020739
+  subpackages:
+  - pkg/syncclient
+  - pkg/syncproto
+  - pkg/tlsutils
 - name: github.com/prometheus/client_golang
   version: 967789050ba94deca04a5e84cce8ad472ce313c1
   subpackages:
   - prometheus
+  - prometheus/promhttp
 - name: github.com/prometheus/client_model
   version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
@@ -244,8 +319,14 @@ imports:
   version: bdcc60b419d136a85cdf2e7cbcac34b3f1cd6e57
   subpackages:
   - codec
+- name: github.com/vishvananda/netlink
+  version: f07d9d5231b9cd05ddf2e5a8ef6582f385bc1770
+  subpackages:
+  - nl
+- name: github.com/vishvananda/netns
+  version: be1fbeda19366dea804f00efff2dd73a1642fdcc
 - name: golang.org/x/crypto
-  version: ab813273cd59e1333f7ae7bff5d027d4aadf528c
+  version: a49355c7e3f8fe157a85be2f77e6e269a0f89602
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -270,7 +351,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: c11f84a56e43e20a78cee75a7c034031ecf57d1f
+  version: 88d2dcc510266da9f7f8c7f34e1940716cab5f5c
   subpackages:
   - unix
   - windows
@@ -324,7 +405,6 @@ imports:
   - credentials
   - grpclb/grpc_lb_v1/messages
   - grpclog
-  - health
   - health/grpc_health_v1
   - internal
   - keepalive
@@ -370,7 +450,7 @@ imports:
   - storage/v1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 40eaf68ee1889b1da1c528b1a075ecfe94e66837
+  version: b593b18191da3eff9afdfd373da5f5e08fe5ac5f
   subpackages:
   - pkg/api/equality
   - pkg/api/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,11 @@ package: github.com/projectcalico/node
 import:
 - package: github.com/sirupsen/logrus
   version: v1.0.4
+- package: github.com/projectcalico/felix
+  version: master
+- package: github.com/kelseyhightower/confd
+  repo: https://github.com/projectcalico/confd.git
+  version: master
 - package: github.com/projectcalico/libcalico-go
   version: d6aff54dc3527357f016c0cd5c5364f21a15e9b4
   subpackages:

--- a/pkg/allocateipip/allocate_ipip_addr.go
+++ b/pkg/allocateipip/allocate_ipip_addr.go
@@ -1,4 +1,4 @@
-package main
+package allocateipip
 
 import (
 	"context"
@@ -24,7 +24,7 @@ import (
 // address if there are any available, otherwise it removes any tunnel address
 // that is configured.
 
-func main() {
+func Run() {
 	// Log to stdout.  this prevents our logs from being interpreted as errors by, for example,
 	// fluentd's default configuration.
 	log.SetOutput(os.Stdout)

--- a/pkg/allocateipip/allocate_ipip_addr_test.go
+++ b/pkg/allocateipip/allocate_ipip_addr_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package allocateipip
 
 import (
 	"context"

--- a/pkg/allocateipip/allocateipip_suite_test.go
+++ b/pkg/allocateipip/allocateipip_suite_test.go
@@ -1,4 +1,4 @@
-package main_test
+package allocateipip_test
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/pkg/readiness/readiness.go
+++ b/pkg/readiness/readiness.go
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package main
+package readiness
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -29,33 +28,28 @@ import (
 
 const felixReadinessEp = "http://localhost:9099/readiness"
 
-var enableBIRDChecks = flag.Bool("bird", false, "Enable BIRD readiness checks")
-var enableBIRD6Checks = flag.Bool("bird6", false, "Enable BIRD6 readiness checks")
-var enableFelixChecks = flag.Bool("felix", false, "Enable felix readiness checks")
+func Run(bird, bird6, felix bool) {
 
-func main() {
-	flag.Parse()
-
-	if !*enableBIRDChecks && !*enableFelixChecks && !*enableBIRD6Checks {
+	if !bird && !felix && !bird6 {
 		fmt.Printf("calico/node readiness check error: must specify at least one of -bird, -bird6, or -felix")
 		os.Exit(1)
 	}
 
-	if *enableFelixChecks {
+	if felix {
 		if err := checkFelixReady(); err != nil {
 			fmt.Printf("calico/node is not ready: felix is not ready: %+v", err)
 			os.Exit(1)
 		}
 	}
 
-	if *enableBIRDChecks {
+	if bird {
 		if err := checkBIRDReady("4"); err != nil {
 			fmt.Printf("calico/node is not ready: BIRD is not ready: %+v", err)
 			os.Exit(1)
 		}
 	}
 
-	if *enableBIRD6Checks {
+	if bird6 {
 		if err := checkBIRDReady("6"); err != nil {
 			fmt.Printf("calico/node is not ready: BIRD6 is not ready: %+v", err)
 			os.Exit(1)

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package main
+package startup
 
 import (
 	"context"
@@ -82,7 +82,7 @@ var (
 // -  Configuring the node resource with IP/AS information provided in the
 //    environment, or autodetected.
 // -  Creating default IP Pools for quick-start use
-func main() {
+func Run() {
 	// Check $CALICO_STARTUP_LOGLEVEL to capture early log statements
 	configureLogging()
 

--- a/pkg/startup/startup_suite_test.go
+++ b/pkg/startup/startup_suite_test.go
@@ -1,4 +1,4 @@
-package main_test
+package startup_test
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package startup
 
 import (
 	"context"

--- a/tests/at/calico_node_goss.yaml
+++ b/tests/at/calico_node_goss.yaml
@@ -31,22 +31,3 @@ package:
     installed: true
   iputils:
     installed: true
-command:
-  /bin/calico-bgp-daemon -v:
-    exit-status: 0
-    stdout:
-    - {{.Env.CALICO_BGP_DAEMON_VER}} 
-    stderr: []
-    timeout: 10000
-  /bin/calico-felix --version:
-    exit-status: 0
-    stdout:
-    - {{.Env.CALICO_FELIX_VER}}
-    stderr: []
-    timeout: 10000
-  /bin/confd -version:
-    exit-status: 0
-    stdout:
-    - {{.Env.CONFD_VER}}
-    stderr: []
-    timeout: 10000

--- a/tests/st/bgp/test_bgp.py
+++ b/tests/st/bgp/test_bgp.py
@@ -53,7 +53,7 @@ class TestReadiness(TestBase):
 
             # Run readiness checks against felix
             self.assertRaisesRegexp(CalledProcessError, "calico/node is not ready: felix is not ready", host1.execute,
-                               "docker exec calico-node /bin/readiness -felix")
+                               "docker exec calico-node /bin/calico-node -felix-ready")
 
     def test_not_ready_with_no_networking_and_broken_felix(self):
         """
@@ -66,7 +66,7 @@ class TestReadiness(TestBase):
 
             # Run readiness checks against felix
             self.assertRaisesRegexp(CalledProcessError, "calico/node is not ready: felix is not ready", host1.execute,
-                               "docker exec calico-node /bin/readiness -felix")
+                               "docker exec calico-node /bin/calico-node -felix-ready")
 
     def test_bird_readiness(self):
         """
@@ -101,9 +101,9 @@ class TestReadiness(TestBase):
 
             # Check that the readiness script is reporting 'not ready'
             self.assertRaisesRegexp(CalledProcessError, "calico/node is not ready: BIRD is not ready: BGP not established with",
-                                    host1.execute, "docker exec calico-node /bin/readiness -bird -felix")
+                                    host1.execute, "docker exec calico-node /bin/calico-node -bird-ready -felix-ready")
             self.assertRaisesRegexp(CalledProcessError, "calico/node is not ready: BIRD is not ready: BGP not established with",
-                                    host1.execute, "docker exec calico-node /bin/readiness -bird -felix")
+                                    host1.execute, "docker exec calico-node /bin/calico-node -bird-ready -felix-ready")
 
             # Restore connectivity
             host1.execute("iptables -t raw -D PREROUTING -p tcp -m multiport --dports 179 -j DROP")

--- a/tests/st/utils/docker_host.py
+++ b/tests/st/utils/docker_host.py
@@ -187,11 +187,11 @@ class DockerHost(object):
             self.start_calico_node(env_options=' -e FELIX_HEALTHENABLED=true ')
 
     def assert_is_ready(self, bird=True, felix=True):
-        cmd = "docker exec calico-node /bin/readiness"
+        cmd = "docker exec calico-node /bin/calico-node"
         if bird:
-            cmd += " -bird"
+            cmd += " -bird-ready"
         if felix:
-            cmd += " -felix"
+            cmd += " -felix-ready"
 
         self.execute(cmd)
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Something I wanted to try - this modifies the calico/node build to produce a single `calico-node` binary, removing the need to produce the following separate binaries:
- calico-felix
- startup
- allocate-ipip-addr
- check-readiness
- confd (needs this PR: https://github.com/projectcalico/confd/pull/132)

Instead, you get something like this:

```
./bin/calico-node -h
Usage of Calico:
  -allocate-ipip-addr
        Allocate an IPIP address for this node
  -bird-ready
        Run BIRD readiness checks
  -bird6-ready
        Run BIRD6 readiness checks
  -confd
        Run confd
  -confd-keep-stage-file
        Keep stage file when running confd
  -confd-run-once
        Run confd in oneshot mode
  -felix
        Run Felix
  -felix-ready
        Run felix readiness checks
  -startup
        Initialize a new node
  -v    Display version
flag: help requested
```

This has some benefits:
- Reduces makefile and build complexity a bunch.
- Reduces image size. Without this PR calico/node is 248 MB. With it, it's 70MB.
- We're now pinning dependencies like Felix and confd, so it gives an easier and more consistent way to trace dependency versions.

I've removed `calico-bgp-daemon` from the build for now, since it doesn't work in v3.X anyway. Once it does, we can add it back in as a vendor dependency rather than a separate binary. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Substantially reduced the calico/node image size by consolidating shared code in a single binary.
```
