### PR TITLE
Add explicit noop for non-amd64 for non-manifest so the target works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,8 @@ push-non-manifests: imagetag $(addprefix sub-non-manifest-,$(call escapefs,$(PUS
 sub-non-manifest-%:
 ifeq ($(ARCH),amd64)
 	docker push $(call unescapefs,$*:$(IMAGETAG))
+else
+	$(NOECHO) $(NOOP)
 endif
 
 ## tag images of one arch for all supported registries
@@ -276,6 +278,8 @@ sub-single-tag-images-arch-%:
 sub-single-tag-images-non-manifest-%:
 ifeq ($(ARCH),amd64)
 	docker tag $(BUILD_IMAGE):latest-$(ARCH) $(call unescapefs,$*:$(IMAGETAG))
+else
+	$(NOECHO) $(NOOP)
 endif
 
 ## tag images of all archs


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The non-manifest targets had an empty recipe for non-`arm64`, but not defined as `PHONY` because they were variable. This created a failure in those archs. This fixes it with an explicit `$(NOOP)`.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```

cc @tomdee 