### PR TITLE
Use JSON instead of YAML as calicoctl input

### DIFF
--- a/tests/st/calicoctl/test_default_pools.py
+++ b/tests/st/calicoctl/test_default_pools.py
@@ -110,8 +110,8 @@ class TestDefaultPools(TestBase):
         assert value in cidrs, "Didn't find %s in %s" % (value, cidrs)
 
         # Dump pools and attempt to load them with calicoctl (to confirm consistency)
-        self.host.calicoctl("get ippool -o yaml > testfile.yaml")
-        self.host.calicoctl("apply -f testfile.yaml")
+        self.host.calicoctl("get ippool -o json > testfile.json")
+        self.host.calicoctl("apply -f testfile.json")
 
         assert len(pools_dict) == exp_num_pools, \
             "Expected %s pools, found %s. %s" % (exp_num_pools, len(pools_dict), pools_dict)

--- a/tests/st/ipam/test_ipam.py
+++ b/tests/st/ipam/test_ipam.py
@@ -93,8 +93,8 @@ class MultiHostIpam(TestBase):
                     'metadata': {'name': 'ippool-name-1'},
                     'spec': {'cidr': str(ipv4_subnet.ipv4())},
                     }
-        self.hosts[0].writefile("newpool.yaml", yaml.dump(new_pool))
-        self.hosts[0].calicoctl("create -f newpool.yaml")
+        self.hosts[0].writejson("newpool.json", new_pool)
+        self.hosts[0].calicoctl("create -f newpool.json")
 
         for host in self.hosts:
             workload = host.create_workload("wlda-%s" % host.name,
@@ -114,7 +114,7 @@ class MultiHostIpam(TestBase):
 
         self.hosts[0].remove_workloads()
 
-        self.hosts[0].calicoctl("delete -f newpool.yaml")
+        self.hosts[0].calicoctl("delete -f newpool.json")
         self.hosts[0].calicoctl("get IPpool -o yaml")
 
         ipv4_subnet = netaddr.IPNetwork("10.0.1.0/24")
@@ -123,8 +123,8 @@ class MultiHostIpam(TestBase):
                     'metadata': {'name': 'ippool-name-2'},
                     'spec': {'cidr': str(ipv4_subnet.ipv4())},
                     }
-        self.hosts[0].writefile("pools.yaml", yaml.dump(new_pool))
-        self.hosts[0].calicoctl("create -f pools.yaml")
+        self.hosts[0].writejson("pools.json", new_pool)
+        self.hosts[0].calicoctl("create -f pools.json")
 
         for host in self.hosts:
             workload = host.create_workload("wlda2-%s" % host.name,
@@ -156,8 +156,8 @@ class MultiHostIpam(TestBase):
                     'metadata': {'name': 'ippool-name-3'},
                     'spec': {'cidr': str(ipv4_subnet.ipv4())},
                     }
-        self.hosts[0].writefile("newpool.yaml", yaml.dump(new_pool))
-        self.hosts[0].calicoctl("create -f newpool.yaml")
+        self.hosts[0].writejson("newpool.json", new_pool)
+        self.hosts[0].calicoctl("create -f newpool.json")
 
         for i in range(num_workloads):
             host = random.choice(self.hosts)
@@ -194,8 +194,8 @@ class MultiHostIpam(TestBase):
                     'metadata': {'name': 'ippool-name-4'},
                     'spec': {'cidr': str(ipv4_subnet.ipv4())},
                     }
-        self.hosts[0].writefile("newpool.yaml", yaml.dump(new_pool))
-        self.hosts[0].calicoctl("create -f newpool.yaml")
+        self.hosts[0].writejson("newpool.json", new_pool)
+        self.hosts[0].calicoctl("create -f newpool.json")
 
         host = self.hosts[0]
         i = 0

--- a/tests/st/libnetwork/test_labeling.py
+++ b/tests/st/libnetwork/test_labeling.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import yaml
-from nose_parameterized import parameterized
 from unittest import skip
 
 from tests.st.test_base import TestBase

--- a/tests/st/policy/test_felix_gateway.py
+++ b/tests/st/policy/test_felix_gateway.py
@@ -883,8 +883,7 @@ class TestFelixOnGateway(TestBase):
             del data['metadata']['creationTimestamp']
 
         # Use calicoctl with the modified data.
-        host.writefile("new_data",
-                       yaml.dump(data, default_flow_style=False))
+        host.writejson("new_data", data)
         host.calicoctl("%s -f new_data" % action)
 
     @classmethod

--- a/tests/st/policy/test_namespace.py
+++ b/tests/st/policy/test_namespace.py
@@ -466,8 +466,7 @@ class TestNamespace(TestBase):
             del data['metadata']['creationTimestamp']
 
         # Use calicoctl with the modified data.
-        host.writefile("new_data",
-                       yaml.dump(data, default_flow_style=False))
+        host.writejson("new_data", data)
         host.calicoctl("%s -f new_data" % action)
 
     @classmethod

--- a/tests/st/policy/test_profile.py
+++ b/tests/st/policy/test_profile.py
@@ -193,8 +193,8 @@ class MultiHostMainline(TestBase):
                 'nets': n1_ips,
             }
         }
-        self.host1.writefile("netset.yaml", yaml.dump(netset, default_flow_style=False))
-        self.host1.calicoctl("create -f netset.yaml")
+        self.host1.writejson("netset.json", netset)
+        self.host1.calicoctl("create -f netset.json")
         netset = {
             'apiVersion': 'projectcalico.org/v3',
             'kind': 'GlobalNetworkSet',
@@ -206,8 +206,8 @@ class MultiHostMainline(TestBase):
                 'nets': n2_ips,
             }
         }
-        self.host1.writefile("netset.yaml", yaml.dump(netset, default_flow_style=False))
-        self.host1.calicoctl("create -f netset.yaml")
+        self.host1.writejson("netset.json", netset)
+        self.host1.calicoctl("create -f netset.json")
 
         # Check initial connectivity before we update the rules to reference the
         # network sets.
@@ -395,8 +395,7 @@ class MultiHostMainline(TestBase):
                 del p['metadata']['creationTimestamp']
 
         # Apply new profiles
-        host.writefile("new_profiles",
-                       yaml.dump(new_profiles, default_flow_style=False))
+        host.writejson("new_profiles", new_profiles)
         host.calicoctl("apply -f new_profiles")
 
     def _setup_workloads(self, host1, host2):

--- a/tests/st/test_base.py
+++ b/tests/st/test_base.py
@@ -292,18 +292,6 @@ class TestBase(TestCase):
             pformat(DeepDiff(thing1, thing2), indent=2)
 
     @staticmethod
-    def writeyaml(filename, data):
-        """
-        Converts a python dict to yaml and outputs to a file.
-        :param filename: filename to write
-        :param data: dictionary to write out as yaml
-        """
-        with open(filename, 'w') as f:
-            text = yaml.dump(data, default_flow_style=False)
-            logger.debug("Writing %s: \n%s" % (filename, text))
-            f.write(text)
-
-    @staticmethod
     def writejson(filename, data):
         """
         Converts a python dict to json and outputs to a file.

--- a/tests/st/utils/docker_host.py
+++ b/tests/st/utils/docker_host.py
@@ -385,8 +385,8 @@ class DockerHost(object):
                 pool['spec']['ipipMode'] = 'Always' if enabled else 'Never'
             if 'creationTimestamp' in pool['metadata']:
                 del pool['metadata']['creationTimestamp']
-        self.writefile("ippools.yaml", yaml.dump(pools_dict))
-        self.calicoctl("apply -f ippools.yaml")
+        self.writejson("ippools.json", pools_dict)
+        self.calicoctl("apply -f ippools.json")
 
     def attach_log_analyzer(self):
         self.log_analyzer = LogAnalyzer(self,
@@ -648,7 +648,7 @@ class DockerHost(object):
 
     def writefile(self, filename, data):
         """
-        Writes a file on a host (e.g. a yaml file for loading into calicoctl).
+        Writes a file on a host (e.g. a JSON file for loading into calicoctl).
         :param filename: string, the filename to create
         :param data: string, the data to put inthe file
         :return: Return code of execute operation.
@@ -715,8 +715,7 @@ class DockerHost(object):
             del data['metadata']['creationTimestamp']
 
         # Use calicoctl with the modified data.
-        self.writefile("new_data",
-                       yaml.dump(data, default_flow_style=False))
+        self.writejson("new_data", data)
         self.calicoctl("%s -f new_data" % action)
 
     def log_extra_diags(self):


### PR DESCRIPTION
This is motivated by a calico/node ST flake in which:

- one of the nodes (DockerHosts) gets a name with a leading 0e,
  specifically 0e5524752632

- there's a step in the test that writes YAML including that name, and
  when it does this the name is not quoted:

```
  apiVersion: projectcalico.org/v3
  kind: Node
  metadata:
    labels:
      routeReflectorClusterID: 224.0.0.2
    name: 0e5524752632
  ...
```

- calicoctl reads that YAML and parses that value as a number, 0 (i.e. 0
  x 10^5524752632 = 0).

I believe this is a mismatch between the test code using PyYAML, which
implements YAML 1.1, and go-yaml-wrapper implementing YAML 1.2.
0e5524752632 is not allowed as a number form in YAML 1.1, so it's
reasonable for YAML 1.1 to write that (knowing that it is a string)
without any quoting.

Options include:
1. Changing test code to use ruamel.yaml instead of PyYAML.  ruamel.yaml
   speaks YAML 1.2, so I believe it would quote in this case.
2. Changing test code to write JSON for calicoctl instead of YAML.

In this change, I've opted for (2), and have changed all cases in the ST
except where YAML is read from calicoctl and then reapplied without
being parsed and regenerated inbetween.
