### PR TITLE
Pin prometheus/client_golang

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7cb4235028f10b59fcdd8411730fd2f88656442ad48b4c6db605204a298aa4dc
-updated: 2018-09-17T07:43:19.660354244Z
+hash: 9a408c0f7d52024f53577b284865346345301546a0d35e1d4e22bb5e4bab360d
+updated: 2018-09-25T14:28:41.883391594Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -14,7 +14,7 @@ imports:
   - autorest/azure
   - autorest/date
 - name: github.com/beorn7/perks
-  version: 3a771d992973f24aa725d07868b467d1ddfceafb
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
   - quantile
 - name: github.com/BurntSushi/toml
@@ -35,7 +35,7 @@ imports:
   - pkg/types
   - version
 - name: github.com/coreos/go-semver
-  version: e214231b295a8ea9479f11b70b35d5acf3556d9b
+  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
   subpackages:
   - semver
 - name: github.com/davecgh/go-spew
@@ -47,7 +47,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: d58d458bec3cb5adec4b7ddb41131855eac0b33f
+  version: 5cf292cae48347c2490ac1a58fe36735fb78df7e
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -106,7 +106,7 @@ imports:
 - name: github.com/kardianos/osext
   version: ae77be60afb1dcacde03767a8c37337fad28ac14
 - name: github.com/kelseyhightower/confd
-  version: 314bdf410382dff541599b1a3ea8fc41678512b6
+  version: 7c21b122e69a21d2ca6e2f26e4ca37b0ecd5dd17
   repo: https://github.com/projectcalico/confd.git
   subpackages:
   - pkg/backends
@@ -185,7 +185,7 @@ imports:
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/projectcalico/felix
-  version: 2894dba45c0338f19206ea836a72eda0fab008a7
+  version: bb9db03cf4f1a30b5c6073b62069aade0ba155b8
   subpackages:
   - buildinfo
   - calc
@@ -226,7 +226,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 2b98cf0202bc20708c94360528a08e9c499f1c11
+  version: bb940fa9d94126edc25a81ee09c8e59f696dc90a
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -283,16 +283,17 @@ imports:
   - pkg/syncproto
   - pkg/tlsutils
 - name: github.com/prometheus/client_golang
-  version: bcbbc08eb2ddff3af83bbf11e7ec13b4fd730b6e
+  version: 773f5027234d0b08adf766be34f55df2f312abf7
   subpackages:
   - prometheus
+  - prometheus/internal
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 7600349dcfe1abd18d72d3a1770870d9800a7801
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -318,7 +319,7 @@ imports:
 - name: github.com/vishvananda/netns
   version: 13995c7128ccc8e51e9a6bd2b551020a27180abd
 - name: golang.org/x/crypto
-  version: c126467f60eb25f8f27e5a981f32a87e3965053f
+  version: 49796115aa4b964c318aad4f3084fdb41e9aa067
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -374,7 +375,7 @@ imports:
   subpackages:
   - rate
 - name: google.golang.org/appengine
-  version: b1f26356af11148e710935ed1ac8a7f5702c7612
+  version: 4216e58b9158e5f1c906f1aca75162a46a2ec88a
   subpackages:
   - internal
   - internal/app_identity

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,16 +9,16 @@ import:
   version: 773f5027234d0b08adf766be34f55df2f312abf7
 - package: github.com/kelseyhightower/confd
   repo: https://github.com/projectcalico/confd.git
-  version: 314bdf410382dff541599b1a3ea8fc41678512b6
+  version: 7c21b122e69a21d2ca6e2f26e4ca37b0ecd5dd17
   subpackages:
   - pkg/config
   - pkg/run
 - package: github.com/projectcalico/felix
-  version: 2894dba45c0338f19206ea836a72eda0fab008a7
+  version: bb9db03cf4f1a30b5c6073b62069aade0ba155b8
   subpackages:
   - daemon
 - package: github.com/projectcalico/libcalico-go
-  version: 2b98cf0202bc20708c94360528a08e9c499f1c11
+  version: bb940fa9d94126edc25a81ee09c8e59f696dc90a
   subpackages:
   - lib/apiconfig
   - lib/apis/v3

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,12 @@
 package: github.com/projectcalico/node
 import:
+# Pin to the client_golang commit that changed NewProcessCollector(pid int, namespace string)
+# to NewProcessCollector(opts ProcessCollectorOpts), because otherwise we get coreos/etcd's
+# pin which is to an earlier point, and then all of our updated NewProcessCollector(...) calls
+# fail to compile.  Ideally we'd be happy with >= 773f5027234d0b08adf766be34f55df2f312abf7,
+# but I don't think glide allows that.
+- package: github.com/prometheus/client_golang
+  version: 773f5027234d0b08adf766be34f55df2f312abf7
 - package: github.com/kelseyhightower/confd
   repo: https://github.com/projectcalico/confd.git
   version: 314bdf410382dff541599b1a3ea8fc41678512b6


### PR DESCRIPTION
Pin to the client_golang commit that changed

    NewProcessCollector(pid int, namespace string)

to

    NewProcessCollector(opts ProcessCollectorOpts)

, because otherwise we get coreos/etcd's pin which is to an earlier
point, and then all of our updated NewProcessCollector(...) calls fail
to compile.  Ideally we'd be happy with >=
773f5027234d0b08adf766be34f55df2f312abf7, but I don't think glide allows
that.

Ref:
https://github.com/prometheus/client_golang/commit/773f5027234d0b08adf766be34f55df2f312abf7
