### PR TITLE
Read env vars from file for confd

### DIFF
--- a/filesystem/etc/service/available/confd/run
+++ b/filesystem/etc/service/available/confd/run
@@ -1,3 +1,6 @@
 #!/bin/sh
 exec 2>&1
+if [ -f /etc/calico/confd/config/env_vars ]; then
+  source /etc/calico/confd/config/env_vars
+fi
 exec calico-node -confd


### PR DESCRIPTION
## Description
I think this would help for those wanting to run IPv6 only where they need to set a CALICO_ROUTER_ID? I'm thinking then an init container could be used to get/calculate an ID (taking care that it will be unique among all nodes) and write it to a file that then the node container can read.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
