### PR TITLE
 Use unidirectional BGP connections in the node-to-node mesh

### DIFF
--- a/filesystem/etc/calico/confd/templates/bird.cfg.template
+++ b/filesystem/etc/calico/confd/templates/bird.cfg.template
@@ -55,6 +55,9 @@ template bgp bgp_template {
   source address {{$node_ip}};  # The local address we use for the TCP connection
   add paths on;
   graceful restart;  # See comment in kernel section about graceful restart.
+  connect delay time 2;
+  connect retry time 5;
+  error wait time 5,30;
 }
 
 # ------------- Node-to-node mesh -------------

--- a/filesystem/etc/calico/confd/templates/bird.cfg.template
+++ b/filesystem/etc/calico/confd/templates/bird.cfg.template
@@ -73,6 +73,15 @@ template bgp bgp_template {
 {{if eq $onode_ip ($node_ip) }}# Skipping ourselves ({{$node_ip}})
 {{else if ne "" $onode_ip}}protocol bgp Mesh_{{$id}} from bgp_template {
   neighbor {{$onode_ip}} as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
+  {{- /*
+       Make the peering unidirectional. This avoids a race where
+       - peer A opens a connection and begins a graceful restart
+       - before the restart completes, peer B opens its connection
+       - peer A sees the new connection and aborts the graceful restart, causing a route flap.
+  */ -}}
+  {{if gt $onode_ip $node_ip}}
+  passive on; # Mesh is unidirectional, peer will connect to us. 
+  {{- end}}
 }{{end}}{{end}}{{end}}
 {{else}}
 # Node-to-node mesh disabled


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Works around a bug in the BGP graceful restart protocol:
if a node is gracefully restarting, and its peer opens a connection
(due to its connection retry timer) before the restart has completed,
the graceful restart is aborted. This results in a route flap.

This change makes it so the BGP connection is only opened in one direction.
If a node is peering with another node that has a (lexicographically)
lesser IP address, we make the connection passive.

Since we're now relying on the connection timer, tune the timer values 
since the defaults are very high (minutes).

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
