### PR TITLE
Fix peering from RR to peer in different AS

### DIFF
--- a/filesystem/etc/calico/confd/templates/bird.cfg.template
+++ b/filesystem/etc/calico/confd/templates/bird.cfg.template
@@ -44,9 +44,11 @@ protocol direct {
 {{else}}{{$node_as_key := printf "/host/%s/as_num" (getenv "NODENAME")}}
 # Template for all BGP clients
 template bgp bgp_template {
+{{- $as_key := or (and (exists $node_as_key) $node_as_key) "/global/as_num"}}
+{{- $node_as_num := getv $as_key}}
   {{template "LOGGING"}}
   description "Connection to BGP peer";
-  local as {{if exists $node_as_key}}{{getv $node_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
+  local as {{$node_as_num}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream
@@ -90,7 +92,7 @@ template bgp bgp_template {
 {{- else}}
 protocol bgp Global_{{$id}} from bgp_template {
   neighbor {{$data.ip}} as {{$data.as_num}};
-{{- if and (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
@@ -111,7 +113,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- else}}
 protocol bgp Node_{{$id}} from bgp_template {
   neighbor {{$data.ip}} as {{$data.as_num}};
-{{- if and (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}

--- a/filesystem/etc/calico/confd/templates/bird6.cfg.template
+++ b/filesystem/etc/calico/confd/templates/bird6.cfg.template
@@ -45,9 +45,11 @@ protocol direct {
 {{else}}{{$node_as_key := printf "/host/%s/as_num" (getenv "NODENAME")}}
 # Template for all BGP clients
 template bgp bgp_template {
+{{- $as_key := or (and (exists $node_as_key) $node_as_key) "/global/as_num"}}
+{{- $node_as_num := getv $as_key}}
   {{template "LOGGING"}}
   description "Connection to BGP peer";
-  local as {{if exists $node_as_key}}{{getv $node_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
+  local as {{$node_as_num}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream
@@ -92,7 +94,7 @@ template bgp bgp_template {
 {{- else}}
 protocol bgp Global_{{$id}} from bgp_template {
   neighbor {{$data.ip}} as {{$data.as_num}};
-{{- if and (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}
@@ -113,7 +115,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- else}}
 protocol bgp Node_{{$id}} from bgp_template {
   neighbor {{$data.ip}} as {{$data.as_num}};
-{{- if and (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
+{{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
   rr cluster id {{$node_cluster_id}};
 {{- end}}


### PR DESCRIPTION
This change cherry-picks the BIRD template changes of
https://github.com/projectcalico/confd/pull/185 to the v3.3 release
branch.  In v3.3 those templates are still part of this node repo,
whereas on master they have moved to confd; hence the cross-repo
cherry-picking.  There will shortly be an associated cherry-pick to v3.3
confd, to add new tests for the
https://github.com/projectcalico/calico/issues/2292 scenario.

## Release Note
```release-note
Fix peering from a calico/node route reflector to a BGP peer in a different autonomous system.
```