### PR TITLE
Allow more time for convergence after BGPPeer config to RRs

### DIFF
--- a/tests/st/bgp/test_internal_route_reflector.py
+++ b/tests/st/bgp/test_internal_route_reflector.py
@@ -89,7 +89,7 @@ class TestInternalRouteReflector(TestBase):
             })
 
             # Allow network to converge (which it now will).
-            self.assert_true(workload_host1.check_can_ping(workload_host2.ip, retries=10))
+            self.assert_true(workload_host1.check_can_ping(workload_host2.ip, retries=20))
 
             # And check connectivity in both directions.
             self.assert_ip_connectivity(workload_list=[workload_host1,

--- a/tests/st/bgp/test_route_reflector_cluster.py
+++ b/tests/st/bgp/test_route_reflector_cluster.py
@@ -113,9 +113,9 @@ class TestRouteReflectorCluster(TestBase):
                     create_bgp_peer(host, "node", rr.ip, 64513, metadata={'name': host.name + rr.name.lower()})
 
             # Allow network to converge (which it now will).
-            self.assert_true(workload_host1.check_can_ping(workload_host2.ip, retries=10))
-            self.assert_true(workload_host1.check_can_ping(workload_host3.ip, retries=10))
-            self.assert_true(workload_host2.check_can_ping(workload_host3.ip, retries=10))
+            self.assert_true(workload_host1.check_can_ping(workload_host2.ip, retries=20))
+            self.assert_true(workload_host1.check_can_ping(workload_host3.ip, retries=20))
+            self.assert_true(workload_host2.check_can_ping(workload_host3.ip, retries=20))
 
             # And check connectivity in both directions.
             self.assert_ip_connectivity(workload_list=[workload_host1,

--- a/tests/st/bgp/test_single_route_reflector.py
+++ b/tests/st/bgp/test_single_route_reflector.py
@@ -62,7 +62,7 @@ class TestSingleRouteReflector(TestBase):
             create_bgp_peer(host1, "global", rg[0].ip, peer_as_num)
 
             # Allow network to converge (which it now will).
-            self.assert_true(workload_host1.check_can_ping(workload_host2.ip, retries=10))
+            self.assert_true(workload_host1.check_can_ping(workload_host2.ip, retries=20))
 
             # And check connectivity in both directions.
             self.assert_ip_connectivity(workload_list=[workload_host1,


### PR DESCRIPTION
I think we've been hitting a BIRD backoff of 30s because of connection
collision; and then this test's allowance of 25s isn't enough.  Details
for a particular
case (https://semaphoreci.com/calico/node-private/branches/confd-start-of-day/builds/1)
are:

Diags collection began at 16:15:15.851326

Ping attempts happened between 16:14:50.919387 and 16:15:14.415218

Problem was workload1_hihxkM failing to ping 192.168.190.0

BGPPeers were configured by 16:14:50.708608

workload1_hihxkM is on host1

At 16:15:30.620864, ip r on host1 includes 192.168.190.0/26 via 172.17.0.4 dev eth0 proto bird

At 16:15:24.877942, ip r on host3 includes 192.168.190.0 dev cali0abb0456e76 scope link

host1's BIRD log, between 16:14:48 (when the BGPPeers were configured) and the end of the test, was:
2018-11-29_16:14:48.69737 bird: Reconfigured
2018-11-29_16:14:50.11571 bird: Node_172_17_0_6: Connected to table master
2018-11-29_16:14:50.11572 bird: Node_172_17_0_6: State changed to feed
2018-11-29_16:14:50.11590 bird: Node_172_17_0_6: State changed to up
2018-11-29_16:14:50.11665 bird: Node_172_17_0_5: Connected to table master
2018-11-29_16:14:50.11665 bird: Node_172_17_0_5: State changed to feed
2018-11-29_16:14:50.11668 bird: Node_172_17_0_5: State changed to up
2018-11-29_16:14:50.11761 bird: Node_172_17_0_5: State changed to start
2018-11-29_16:14:52.12290 bird: Node_172_17_0_5: State changed to feed
2018-11-29_16:14:52.12291 bird: Node_172_17_0_5: Received: Connection collision resolution
2018-11-29_16:14:52.12291 bird: Node_172_17_0_5: State changed to stop
2018-11-29_16:14:52.12302 bird: Node_172_17_0_5: State changed to down
2018-11-29_16:14:52.12302 bird: Node_172_17_0_5: Starting
2018-11-29_16:14:52.12302 bird: Node_172_17_0_5: State changed to start
2018-11-29_16:14:54.12649 bird: Node_172_17_0_5: Connected to table master
2018-11-29_16:14:54.12650 bird: Node_172_17_0_5: State changed to feed
2018-11-29_16:14:54.12670 bird: Node_172_17_0_5: State changed to up
2018-11-29_16:15:21.95556 bird: Node_172_17_0_6: State changed to start
2018-11-29_16:15:24.10718 bird: Node_172_17_0_5: State changed to start```

