### PR TITLE
Rationalize ST calicoctl calling code

### DIFF
--- a/tests/st/calicoctl/test_node_status.py
+++ b/tests/st/calicoctl/test_node_status.py
@@ -45,5 +45,5 @@ class TestNodeStatus(TestBase):
                 self.assertEquals(e.output,
                                   "Calico process is not running.\n")
             else:
-                raise AssertionError("'calicoctl status' did not exit with "
-                                     "code 1 when node was not running")
+                raise AssertionError("'calicoctl node status' did not exit"
+                                     " with code 1 when node was not running")

--- a/tests/st/policy/test_felix_gateway.py
+++ b/tests/st/policy/test_felix_gateway.py
@@ -854,15 +854,7 @@ class TestFelixOnGateway(TestBase):
         retry_until_success(self.assert_host_can_curl_ext)
 
     def delete_all(self, resource):
-        # Grab all objects of a resource type
-        objects = yaml.load(self.hosts[0].calicoctl("get %s -o yaml" % resource))
-        # and delete them (if there are any)
-        if len(objects) > 0:
-            _log.info("objects: %s", objects)
-            if 'items' in objects and len(objects['items']) == 0:
-                pass
-            else:
-                self.hosts[0]._delete_data(objects)
+        self.hosts[0].delete_all_resource(resource)
 
     @classmethod
     def get_container_ip(cls, container_name):

--- a/tests/st/policy/test_felix_gateway.py
+++ b/tests/st/policy/test_felix_gateway.py
@@ -715,7 +715,7 @@ class TestFelixOnGateway(TestBase):
         })
 
     def add_policy(self, policy_data):
-        self._apply_resources(policy_data, self.gateway)
+        self.gateway._apply_resources(policy_data)
 
     def add_gateway_internal_iface(self):
         host_endpoint_data = {
@@ -730,7 +730,7 @@ class TestFelixOnGateway(TestBase):
                 'interfaceName': 'eth0'
             }
         }
-        self._apply_resources(host_endpoint_data, self.gateway)
+        self.gateway._apply_resources(host_endpoint_data)
 
     def add_gateway_external_iface(self):
         host_endpoint_data = {
@@ -745,7 +745,7 @@ class TestFelixOnGateway(TestBase):
                 'interfaceName': 'eth1'
             }
         }
-        self._apply_resources(host_endpoint_data, self.gateway)
+        self.gateway._apply_resources(host_endpoint_data)
 
     def add_host_iface(self):
         host_endpoint_data = {
@@ -761,7 +761,7 @@ class TestFelixOnGateway(TestBase):
                 'expectedIPs': [str(self.host.ip)],
             }
         }
-        self._apply_resources(host_endpoint_data, self.gateway)
+        self.gateway._apply_resources(host_endpoint_data)
 
     def assert_host_can_curl_local(self):
         try:
@@ -862,29 +862,7 @@ class TestFelixOnGateway(TestBase):
             if 'items' in objects and len(objects['items']) == 0:
                 pass
             else:
-                self._delete_data(objects, self.hosts[0])
-
-    def _delete_data(self, data, host):
-        _log.debug("Deleting data with calicoctl: %s", data)
-        self._exec_calicoctl("delete", data, host)
-
-    @classmethod
-    def _apply_resources(cls, resources, host):
-        cls._exec_calicoctl("apply", resources, host)
-
-    @staticmethod
-    def _exec_calicoctl(action, data, host):
-        # Delete creationTimestamp fields from the data that we're going to
-        # write.
-        for obj in data.get('items', []):
-            if 'creationTimestamp' in obj['metadata']:
-                del obj['metadata']['creationTimestamp']
-        if 'metadata' in data and 'creationTimestamp' in data['metadata']:
-            del data['metadata']['creationTimestamp']
-
-        # Use calicoctl with the modified data.
-        host.writejson("new_data", data)
-        host.calicoctl("%s -f new_data" % action)
+                self.hosts[0]._delete_data(objects)
 
     @classmethod
     def get_container_ip(cls, container_name):

--- a/tests/st/policy/test_namespace.py
+++ b/tests/st/policy/test_namespace.py
@@ -436,15 +436,7 @@ class TestNamespace(TestBase):
 
     @classmethod
     def delete_all(cls, resource):
-        # Grab all objects of a resource type
-        objects = yaml.load(cls.hosts[0].calicoctl("get %s -o yaml" % resource))
-        # and delete them (if there are any)
-        if len(objects) > 0:
-            _log.info("objects: %s", objects)
-            if 'items' in objects and len(objects['items']) == 0:
-                pass
-            else:
-                cls.hosts[0]._delete_data(objects)
+        cls.hosts[0].delete_all_resource(resource)
 
     @classmethod
     def get_container_ip(cls, container_name):

--- a/tests/st/policy/test_namespace.py
+++ b/tests/st/policy/test_namespace.py
@@ -383,10 +383,10 @@ class TestNamespace(TestBase):
                 ],
             }
         }
-        cls._apply_resources(profile_data, cls.host1)
+        cls.host1._apply_resources(profile_data)
 
     def add_policy(self, policy_data):
-        self._apply_resources(policy_data, self.host1)
+        self.host1._apply_resources(policy_data)
 
     def check_namespace_access(self, target, nsa_can, nsb_can, default_can):
         assert_func = {
@@ -444,30 +444,7 @@ class TestNamespace(TestBase):
             if 'items' in objects and len(objects['items']) == 0:
                 pass
             else:
-                cls._delete_data(objects, cls.hosts[0])
-
-    @classmethod
-    def _delete_data(cls, data, host):
-        _log.debug("Deleting data with calicoctl: %s", data)
-        cls._exec_calicoctl("delete", data, host)
-
-    @classmethod
-    def _apply_resources(cls, resources, host):
-        cls._exec_calicoctl("apply", resources, host)
-
-    @staticmethod
-    def _exec_calicoctl(action, data, host):
-        # Delete creationTimestamp fields from the data that we're going to
-        # write.
-        for obj in data.get('items', []):
-            if 'creationTimestamp' in obj['metadata']:
-                del obj['metadata']['creationTimestamp']
-        if 'metadata' in data and 'creationTimestamp' in data['metadata']:
-            del data['metadata']['creationTimestamp']
-
-        # Use calicoctl with the modified data.
-        host.writejson("new_data", data)
-        host.calicoctl("%s -f new_data" % action)
+                cls.hosts[0]._delete_data(objects)
 
     @classmethod
     def get_container_ip(cls, container_name):


### PR DESCRIPTION
Just deleting some duplicate code here.  But with an eye on moving towards a clearer abstraction of calicoctl operations, so that we might eventually be able to use useful functions like update_bgp_config in both the tests/st and tests/k8st suites.  (Currently we can't do that, because the code underneath update_bgp_config boils down to
```
docker exec <host container> calicoctl ...
```
whereas the setup for tests/k8st requires
```
kubectl exec -i -n kube-system calicoctl -- /calicoctl ...
```
)