### PR TITLE
[V3.2]Backporting changes from master for bird readiness check to avoid aggresive update.

### DIFF
--- a/cmd/calico-node/main.go
+++ b/cmd/calico-node/main.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	confdConfig "github.com/kelseyhightower/confd/pkg/config"
 	confd "github.com/kelseyhightower/confd/pkg/run"
@@ -44,6 +45,9 @@ var birdReady = flagSet.Bool("bird-ready", false, "Run BIRD readiness checks")
 var bird6Ready = flagSet.Bool("bird6-ready", false, "Run BIRD6 readiness checks")
 var felixReady = flagSet.Bool("felix-ready", false, "Run felix readiness checks")
 
+// thresholdTime is introduced for bird readiness check. Default value is 30 sec.
+var thresholdTime = flagSet.Duration("threshold-time", 30*time.Second, "Threshold time for bird readiness")
+
 // confd flags
 var runConfd = flagSet.Bool("confd", false, "Run confd")
 var confdRunOnce = flagSet.Bool("confd-run-once", false, "Run confd in oneshot mode")
@@ -63,6 +67,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Threshold time for bgp peering
+	fmt.Println("Threshold time for bird readiness check: ", *thresholdTime)
+
 	// Perform some validation on the parsed flags. Only one of the following may be
 	// specified at a time.
 	onlyOne := []*bool{version, runFelix, runStartup, runConfd}
@@ -80,7 +87,7 @@ func main() {
 
 	// If any of the readienss options are provided, check readiness.
 	if *birdReady || *bird6Ready || *felixReady {
-		readiness.Run(*birdReady, *bird6Ready, *felixReady)
+		readiness.Run(*birdReady, *bird6Ready, *felixReady, *thresholdTime)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This is a back-porting of changes from master for bird readiness check to avoid aggressive update in case of issue during rolling update.