### PR TITLE
Avoid apparent pyyaml vulnerability

### DIFF
--- a/calico_test/requirements.txt
+++ b/calico_test/requirements.txt
@@ -2,7 +2,7 @@ nose==1.3.7
 nose-timer==0.7.1
 nose-parameterized==0.6.0
 netaddr==0.7.19
-pyyaml==3.12
+pyyaml>=4.2b1
 simplejson==3.13.2
 deepdiff==3.3.0
 kubernetes

--- a/tests/k8st/tests/test_bgp_advert.py
+++ b/tests/k8st/tests/test_bgp_advert.py
@@ -16,7 +16,6 @@ import os
 import subprocess
 import unittest
 import json
-import yaml
 from time import sleep
 from netaddr import IPAddress
 

--- a/tests/st/bgp/peer.py
+++ b/tests/st/bgp/peer.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import yaml
 
 def create_bgp_peer(host, scope, ip, asNum, metadata=None):
     assert scope in ('node', 'global')

--- a/tests/st/bgp/test_global_config.py
+++ b/tests/st/bgp/test_global_config.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import yaml
 from nose.plugins.attrib import attr
 from unittest import skip
 

--- a/tests/st/config/test_felix_config.py
+++ b/tests/st/config/test_felix_config.py
@@ -16,7 +16,6 @@ import logging
 import time
 from functools import partial
 
-import yaml
 from tests.st.test_base import TestBase, HOST_IPV4
 from tests.st.utils.docker_host import DockerHost, CLUSTER_STORE_DOCKER_OPTIONS
 from tests.st.utils.utils import log_and_run, retry_until_success, \

--- a/tests/st/policy/test_felix_gateway.py
+++ b/tests/st/policy/test_felix_gateway.py
@@ -16,7 +16,6 @@ import json
 import logging
 import subprocess
 
-import yaml
 from tests.st.test_base import TestBase, HOST_IPV4
 from tests.st.utils.docker_host import DockerHost, CLUSTER_STORE_DOCKER_OPTIONS
 from tests.st.utils.utils import get_ip, log_and_run, retry_until_success, \

--- a/tests/st/policy/test_namespace.py
+++ b/tests/st/policy/test_namespace.py
@@ -16,7 +16,6 @@ import json
 import logging
 import subprocess
 
-import yaml
 from tests.st.test_base import TestBase, HOST_IPV4
 from tests.st.utils.docker_host import DockerHost, CLUSTER_STORE_DOCKER_OPTIONS
 from tests.st.utils.utils import get_ip, log_and_run, retry_until_success, \

--- a/tests/st/utils/docker_host.py
+++ b/tests/st/utils/docker_host.py
@@ -690,7 +690,7 @@ class DockerHost(object):
         :param resource: string, resource type to delete
         """
         # Grab all objects of a resource type
-        objects = yaml.load(self.calicoctl("get %s -o yaml" % resource))
+        objects = yaml.safe_load(self.calicoctl("get %s -o yaml" % resource))
         # and delete them (if there are any)
         if len(objects) > 0:
             if 'items' in objects and len(objects['items']) == 0:


### PR DESCRIPTION
GitHub says:
```
  1 pyyaml vulnerability found in calico_test/requirements.txt 13 hours ago
  Remediation
  Upgrade pyyaml to version 4.2b1 or later. For example:

  pyyaml>=4.2b1
  Always verify the validity and compatibility of suggestions with your codebase.

  Details
  CVE-2017-18342 More information
  high severity
  Vulnerable versions: < 4.2b1
  Patched version: 4.2b1
  In PyYAML before 4.1, the yaml.load() API could execute arbitrary
  code. In other words, yaml.safe_load is not used.
```
Also change remaining uses of `yaml.load` to `yaml.safe_load`.
