### PR TITLE
Modifying Dockerfile.amd64  to use debian instead of alpine as base

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -14,13 +14,40 @@
 ARG BIRD_IMAGE=calico/bird:latest
 FROM ${BIRD_IMAGE} as bird
 
-FROM alpine:3.8
-MAINTAINER Tom Denham <tom@projectcalico.org>
+FROM debian:buster-slim
+LABEL maintainer "Casey Davenport <casey@tigera.io>"
 
 ARG ARCH=amd64
 
 # Install remaining runtime deps required for felix from the global repository
-RUN apk add --no-cache ip6tables ipset iputils iproute2 conntrack-tools runit ca-certificates
+RUN apt-get update && apt-get install -y \
+    ipset \
+    # For debian:buster-slim, iptables is v1.8.2 
+    iptables \ 
+    iputils-arping \
+    iputils-ping \
+    iputils-tracepath \
+    # Need arp 
+    net-tools \ 
+    iproute2 \ 
+    conntrack \ 
+    runit \ 
+    # Need kmod to ensure ip6tables-save works correctly
+    kmod \ 
+    # Also needed (provides utilities for browsing procfs like ps) 
+    procps \    
+    ca-certificates
+
+# Starting with iptables v1.8.2 the binary package includes iptables-nft and
+# iptables-legacy, two variants of the iptables command line interface. The
+# nftables-based is the default in Debian Buster and works with the nf_tables
+# Linux kernel subsystem. The legacy one uses the x_tables Linux kernel
+# subsystem. Users can use the update-alternatives system to select one variant
+# or the other.
+# Force iptables and ip6tables to use legacy and output their status afterwards
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy && \ 
+    update-alternatives --get-selections
 
 # Copy our bird binaries in
 COPY --from=bird /bird* /bin/

--- a/Makefile
+++ b/Makefile
@@ -491,6 +491,10 @@ k8s-stop: tests/k8st/$(DIND_SCR)
 .PHONY: k8s-run-test
 ## Run k8st in an existing k8s cluster
 k8s-run-test: calico_test.created
+## Only execute remove-go-build-image if flag is set
+ifeq ($(REMOVE_GOBUILD_IMG),true)
+	$(MAKE) remove-go-build-image
+endif
 	docker run \
 	    -v $(CURDIR):/code \
 	    -v /var/run/docker.sock:/var/run/docker.sock \
@@ -501,6 +505,12 @@ k8s-run-test: calico_test.created
         $(TEST_CONTAINER_NAME) \
 	    sh -c 'cp /root/.kubeadm-dind-cluster/kubectl /bin/kubectl && ls -ltr /bin/kubectl && which kubectl && cd /code/tests/k8st && \
 	           nosetests $(K8ST_TO_RUN) -v --with-xunit --xunit-file="/code/report/k8s-tests.xml" --with-timer'
+
+# Needed for Semaphore CI (where disk space is a real issue during k8s-test)
+.PHONY: remove-go-build-image
+remove-go-build-image:
+	@echo "Removing $(CALICO_BUILD) image to save space needed for testing ..."
+	@-docker rmi $(CALICO_BUILD)
 
 .PHONY: st
 ## Run the system tests

--- a/README.md
+++ b/README.md
@@ -24,3 +24,124 @@ The code in this repository can be built and tested using the Makefile.
 For more information, see `make help`.
 
 [contrib]: https://github.com/projectcalico/calico/blob/master/CONTRIBUTING_CODE.md
+
+## How can I run tests?
+
+Tests for this repo are divided into the following categories: 
+- `fv`: Package scoped tests
+- `st`: System integration tests 
+- `k8s-test`: Kubernetes integration tests 
+
+Assuming you have installed the necessary depedencies (see below for details), you can run any of the above categories using: 
+```
+make <target>
+```
+Where `target` is one of `fv`, `st`, or `k8s-test`. You can also use `test`, which aggregates `fv` and `st`. 
+
+### Dependencies for running tests
+
+If you want to be able to run tests locally, you will need to install:
+- GNU make
+
+For `st` system integration tests, node uses: 
+- Python (>= 2.7 ???)
+- [Nose](https://nose.readthedocs.io/en/latest/)
+
+For `fv` packaged scoped tests, node uses: 
+- Golang (>=1.7)
+- [Ginkgo](https://github.com/onsi/ginkgo)
+
+You will also need to install Ginkgo explicitly: 
+```
+go get -u github.com/Masterminds/glide
+go get -u github.com/onsi/ginkgo/ginkgo
+```
+
+For `k8s-test` Kubernetes tests, you will need to have `kubectl` setup on your machine. Go here for [instructions on setting up `kubectl` for your environment](https://kubernetes.io/docs/tasks/tools/install-kubectl/).  
+
+## How can I run a subset of the tests?
+
+If you want to run tests for a specific package for more iterative development, you can filter down into a subset of tests using the following parameters: 
+- For filtering `st` tests, use `ST_TO_RUN` 
+- For filtering `k8s-test` tests, use `K8ST_TO_RUN` 
+
+For example, the following only runs tests within the `bgp` subfolder of the `st` category: 
+```
+make st ST_TO_RUN="tests/st/bgp/"
+```
+
+To only run tests from a single file (e.g. `test_bgp.py`), use the following: 
+```
+make st ST_TO_RUN="tests/st/bgp/test_bgp.py"
+```
+
+To only run a single test within a test file use the below syntax: 
+```
+make st ST_TO_RUN="tests/st/bgp/test_bgp.py:TestReadiness.test_readiness_multihost"
+```
+
+The above examples should apply in the same fashion if you are using `K8ST_TO_RUN` instead for the `k8s-test` category. 
+
+## How do I debug tests?
+There are a number of possible avenues you can use to debug failing tests. 
+
+1. Review the diagnostic logs after the tests finish running 
+- These only show for failed tests
+- Be warned the logs are quite verbose 
+2. Use the parameter `DEBUG_FAILURES` with the Makefile 
+```
+make st DEBUG_FAILURES=true
+```
+- This only applies to `st` tests 
+- A subset of the `st` are wrapped by `debug_failures(fn)` function found in `./tests/st/utils/utils.py`
+- You should be able to wrap whatever test you want 
+- Uses Python's `pdb.set_trace()` library function, allows you to halt executino and step into the containers involved in the test for debugging 
+3. Use manual breakpoints 
+- A more primitive approach is just to add your own breakpoints (using something like `time.sleep(x)`)
+- You should know where to add these after reviewing the diagnostic logs for failed tests (by looking at the stacktraces)
+
+## Linux Dependencies 
+Below is a listing of userspace tools packaged into the node container. The list is not exhuastive, but highlights some of the key dependencies required for node to operate correctly. 
+
+- [`/user/sbin/arp`](http://man7.org/linux/man-pages/man8/arp.8.html)
+    - Manipulate the system ARP cache
+    - Package: `net-tools`
+- [`/user/sbin/conntrack`](http://man7.org/linux/man-pages/man8/arp.8.html)
+    - Netfilter connection tracking
+    - Package: `conntrack`
+- [`/bin/ip`](https://linux.die.net/man/8/ip)
+    - Show / manipulate routing, devices, policy routing and tunnels
+    - Package: `iproute2`
+- [`/usr/sbin/iptables`](https://linux.die.net/man/8/iptables)
+    - Admin tool for IPv4 packet filtering and NAT
+    - Note, we're using the legacy version `iptables-legacy → xtables-legacy-multi` (divergence introduced in `iptables v1.8.2`)
+    - Package: `iptables`
+- [`/usr/sbin/iptables-restore`](https://linux.die.net/man/8/iptables-restore)
+    - Note, we're using the legacy version `iptables-legacy-restore → xtables-legacy-multi` (divergence introduced in `iptables v1.8.2`)
+    - Package: `iptables`
+- [`/usr/sbin/iptables-save`](https://linux.die.net/man/8/iptables-save)
+    - Note, we're using the legacy version `iptables-legacy-save → xtables-legacy-multi` (divergence introduced in `iptables v1.8.2`)
+    - Package: `iptables`
+- [`/usr/sbin/ip6tables`](https://linux.die.net/man/8/ip6tables)
+    - Admin tool for IPv6 packet filtering and NAT
+    - Note, we're using the legacy version `ip6tables-legacy → xtables-legacy-multi` (divergence introduced in `iptables v1.8.2`)
+    - Package: `iptables`
+- `/usr/sbin/ip6tables-restore`
+    - Note, we using the legacy version `ip6tables-legacy-restore → xtables-legacy-multi` (divergence introduced in `iptables v1.8.2`)
+    - Package: `iptables`
+- `/usr/sbin/ip6tables-save`
+    - Note, we using the legacy version `ip6tables-legacy-save → xtables-legacy-multi` (divergence introduced in `iptables v1.8.2`)
+    - Package: `iptables`
+- [`/bin/ps`](https://linux.die.net/man/1/ps)
+    - Snapshot of the current processes 
+    - Package: `procps`
+- [`/bin/kmod`](http://man7.org/linux/man-pages/man8/kmod.8.html)
+    - Manage Linux Kernel modules 
+    - soft link for `depmod`, `insmod`, `lsmod`, `modinfo`, `modprobe`, `rmmo`
+    - Package: `kmod`
+- [`/sbin/runit`](http://smarden.org/runit/)
+    - Init scheme with service supervision
+    - Package: `runit`
+- [`/usr/sbin/runsvchdir`](http://smarden.org/runit/runsvdir.8.html)
+    - Starts and monitors a collection of runsv processes
+    - Package: `runit`

--- a/filesystem/etc/rc.local
+++ b/filesystem/etc/rc.local
@@ -1,7 +1,7 @@
 # Handle old CALICO_NETWORKING environment by converting to the new config.
 if [ -n "$CALICO_NETWORKING" ]; then
-	echo 'WARNING: $CALICO_NETWORKING will be deprecated: use $CALICO_NETWORKING_BACKEND instead'
-	if [ "$CALICO_NETWORKING" == "false" ]; then
+	echo "WARNING: $CALICO_NETWORKING will be deprecated: use $CALICO_NETWORKING_BACKEND instead"
+	if [ "$CALICO_NETWORKING" = "false" ]; then
 		export CALICO_NETWORKING_BACKEND=none
 	else
 		export CALICO_NETWORKING_BACKEND=bird
@@ -17,7 +17,8 @@ if [ ! -f "/var/lib/calico/nodename" ]; then
 	echo "/var/lib/calico/nodename does not exist, exiting"
 	exit 1
 fi
-export NODENAME=$(cat /var/lib/calico/nodename)
+NODENAME=$(cat /var/lib/calico/nodename)
+export NODENAME
 
 # If possible pre-allocate the IP address on the IPIP tunnel.
 calico-node -allocate-ipip-addr || exit 1
@@ -58,12 +59,12 @@ esac
 
 # If running libnetwork plugin in a separate container, CALICO_LIBNETWORK_ENABLED would be false.
 # CALICO_LIBNETWORK_ENABLED is "false" by default. It can be set by passing `--libnetwork` flag while starting the calico/node via calicoctl
-if [ "$CALICO_LIBNETWORK_ENABLED" == "true" ]; then
+if [ "$CALICO_LIBNETWORK_ENABLED" = "true" ]; then
 	echo "Starting libnetwork service"
 	cp -a /etc/service/available/libnetwork  /etc/service/enabled/
 fi
 
-if [ "$CALICO_DISABLE_FILE_LOGGING" == "true" ]; then
+if [ "$CALICO_DISABLE_FILE_LOGGING" = "true" ]; then
 	rm -rf /etc/service/enabled/bird/log
 	rm -rf /etc/service/enabled/bird6/log
 	rm -rf /etc/service/enabled/confd/log

--- a/filesystem/sbin/start_runit
+++ b/filesystem/sbin/start_runit
@@ -13,4 +13,4 @@ fi
 # Export the nodename set by the startup procedure. 
 export NODENAME=$(cat /var/lib/calico/nodename)
 
-exec /sbin/runsvdir -P /etc/service/enabled
+exec /usr/bin/runsvdir -P /etc/service/enabled


### PR DESCRIPTION
## Description
Modifying Dockerfiles to use debian instead of alpine as base for copying over dependencies.

## Todos
- [x] Tests
    - Ensure all existing tests are passing
- [x] Documentation
    - Add something to README.md about testing Calico node
- [ ] ~~Release note~~

## Release Note
```release-note
None required
```

