### PR TITLE
Don't allocate a tunnel address if using k8s pod CIDR allocations

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c7b76d71cf14d5d450b120f17031506b91ead90e54d23f4e57aee2757f172328
-updated: 2019-04-19T07:42:53.967680988Z
+hash: 7a0a9aab20ee4699e0db9c4bcfb365168ba52cf80e5c88c71911689ae7abeac4
+updated: 2019-04-23T18:28:51.45947138Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -14,7 +14,7 @@ imports:
   - autorest/azure
   - autorest/date
 - name: github.com/beorn7/perks
-  version: 3a771d992973f24aa725d07868b467d1ddfceafb
+  version: 4b2b341e8d7715fae06375aa633dbb6e91b3fb46
   subpackages:
   - quantile
 - name: github.com/BurntSushi/toml
@@ -57,9 +57,9 @@ imports:
 - name: github.com/gobuffalo/envy
   version: 043cb4b8af871b49563291e32c66bb84378a60ac
 - name: github.com/gobuffalo/genny
-  version: 3ca520ef0d9ea4981534aae98bf9a003d9b18678
+  version: 34bef62e8202ea5e6dd1f9ee3d5ac217f1290352
 - name: github.com/gobuffalo/gogen
-  version: 8f38393713f59beb43221f903c07f58f0377a063
+  version: 5482e6ef5d999f8cfa9b038a53953c9b4ee090af
   subpackages:
   - goimports
   - gomods
@@ -68,7 +68,7 @@ imports:
 - name: github.com/gobuffalo/mapi
   version: 0bb5e840be332d4280e40f2e6c50777c615bbac5
 - name: github.com/gobuffalo/packd
-  version: a385830c7fc0495b810318788a043c7655da337d
+  version: 9efbb667f2024a9370cadda45a57a0657c88a6fb
 - name: github.com/gobuffalo/packr
   version: 68a5fdc58d980600c4622a82472ebe415048f141
   subpackages:
@@ -122,13 +122,13 @@ imports:
   subpackages:
   - diskcache
 - name: github.com/hashicorp/go-version
-  version: d40cf49b3a77bba84a7afdbd7f1dc295d114efb1
+  version: ac23dc3fea5d1a983c43f6a0f6e2c13f0195d8bd
 - name: github.com/hashicorp/golang-lru
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   subpackages:
   - simplelru
 - name: github.com/hpcloud/tail
-  version: a1dbeea552b7c8df4b542c66073e393de198a800
+  version: a30252cb686a21eb2d0b98132633053ec2f7f1e5
   subpackages:
   - ratelimiter
   - util
@@ -217,7 +217,7 @@ imports:
 - name: github.com/pkg/errors
   version: 27936f6d90f9c8e1145f11ed52ffffbfdb9e0af7
 - name: github.com/projectcalico/felix
-  version: 3774b6b48ee739b326598f9978147fa85650c2a0
+  version: 72c3f4986d5e447b8b08365b1c63176c14ab3ec0
   subpackages:
   - bpf
   - bpf/packrd
@@ -258,7 +258,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 43c1da882b70aba9d0325e7de4393439ef202550
+  version: 43d572414857cc6f4d7242d9a23422cbc552f84a
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -327,7 +327,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 5df5c82edb7502fd6cbe093223a19b6e1231494f
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -358,9 +358,9 @@ imports:
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 13995c7128ccc8e51e9a6bd2b551020a27180abd
+  version: 54f0e4339ce73702a0607f49922aaa1e749b418d
 - name: golang.org/x/crypto
-  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  version: 49796115aa4b964c318aad4f3084fdb41e9aa067
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -416,11 +416,18 @@ imports:
   subpackages:
   - rate
 - name: golang.org/x/tools
-  version: 4735f53fb37db012e63d1a62914417980fb3c023
+  version: fe54fb35175bb1c0c175e2335e23d7fa90ca987a
   subpackages:
   - go/ast/astutil
+  - go/gcexportdata
+  - go/internal/gcimporter
+  - go/internal/packagesdriver
+  - go/packages
   - imports
   - internal/fastwalk
+  - internal/gopathwalk
+  - internal/module
+  - internal/semver
 - name: google.golang.org/appengine
   version: 54a98f90d1c46b7731eb8fb305d2a321c30ef610
   subpackages:
@@ -457,8 +464,8 @@ imports:
   - status
   - tap
   - transport
-- name: gopkg.in/fsnotify/fsnotify.v1
-  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
+- name: gopkg.in/fsnotify.v1
+  version: 7be54206639f256967dd82fa767397ba5f8f48f5
 - name: gopkg.in/go-playground/validator.v9
   version: 46b4b1e301c24cac870ffcb4ba5c8a703d1ef475
 - name: gopkg.in/inf.v0

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,11 +14,11 @@ import:
   - pkg/config
   - pkg/run
 - package: github.com/projectcalico/felix
-  version: 3774b6b48ee739b326598f9978147fa85650c2a0
+  version: 72c3f4986d5e447b8b08365b1c63176c14ab3ec0
   subpackages:
   - daemon
 - package: github.com/projectcalico/libcalico-go
-  version: 43c1da882b70aba9d0325e7de4393439ef202550
+  version: 43d572414857cc6f4d7242d9a23422cbc552f84a
   subpackages:
   - lib/apiconfig
   - lib/apis/v3

--- a/pkg/allocateip/allocateip.go
+++ b/pkg/allocateip/allocateip.go
@@ -36,7 +36,13 @@ func Run() {
 	logrus.AddHook(&logutils.ContextHook{})
 
 	// Load the client config from environment.
-	_, c := calicoclient.CreateClient()
+	cfg, c := calicoclient.CreateClient()
+
+	// If configured to use host-local IPAM, this script has nothing to do, so just return.
+	if cfg.Spec.K8sUsePodCIDR {
+		logrus.Debug("Using host-local IPAM, no need to allocate a tunnel IP")
+		return
+	}
 
 	// This binary is only ever invoked _after_ the
 	// startup binary has been invoked and the modified environments have


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Relies on https://github.com/projectcalico/libcalico-go/pull/1077

If we're not using Calico IPAM, we can't assign addresses in Calico
IPAM!

- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```