### PR TITLE
Switching image base to debian:9.8-slim

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -16,16 +16,19 @@ ARG BIRD_IMAGE=calico/bird:latest
 FROM calico/bpftool:v5.0-amd64 as bpftool
 FROM ${BIRD_IMAGE} as bird
 
-FROM debian:buster-slim
+FROM debian:9.8-slim
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 
 ARG ARCH=amd64
 
+# Install a backported version of iptables to ensure we have version 1.6.2
+RUN printf "deb http://deb.debian.org/debian stretch-backports main\n" > /etc/apt/sources.list.d/backports.list \ 
+    && apt-get update \
+    && apt-get -t stretch-backports install -y iptables 
+
 # Install remaining runtime deps required for felix from the global repository
 RUN apt-get update && apt-get install -y \
     ipset \
-    # For debian:buster-slim, iptables is v1.8.2 
-    iptables \ 
     iputils-arping \
     iputils-ping \
     iputils-tracepath \
@@ -42,17 +45,6 @@ RUN apt-get update && apt-get install -y \
     # Also needed (provides utilities for browsing procfs like ps) 
     procps \    
     ca-certificates
-
-# Starting with iptables v1.8.2 the binary package includes iptables-nft and
-# iptables-legacy, two variants of the iptables command line interface. The
-# nftables-based is the default in Debian Buster and works with the nf_tables
-# Linux kernel subsystem. The legacy one uses the x_tables Linux kernel
-# subsystem. Users can use the update-alternatives system to select one variant
-# or the other.
-# Force iptables and ip6tables to use legacy and output their status afterwards
-RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
-    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy && \ 
-    update-alternatives --get-selections
 
 # Copy our bird binaries in
 COPY --from=bird /bird* /bin/


### PR DESCRIPTION
## Description
Switching image base to debian:9.8-slim (aka stretch-slim). Ensuring that image has iptables v1.6.2 to match what was in our alpine build.

The reason for the switch is that Debian stretch is the current stable LTS release.

This is a patch for `release-v3.7` based on the following PR: 
https://github.com/projectcalico/node/pull/223

## Todos
- [x] Tests
- [ ] ~~Documentation~~
- [ ] ~~Release note~~

## Release Note

```release-note
node base image switched to Debian stretch (LTS)
```
