### PR TITLE
Increase K8S version to 1.14.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ ifneq ($(BUILDARCH),amd64)
         ETCD_IMAGE=$(ETCD_IMAGE)-$(ARCH)
 endif
 
-K8S_VERSION?=v1.11.3
+K8S_VERSION?=v1.14.1
 HYPERKUBE_IMAGE?=gcr.io/google_containers/hyperkube-$(ARCH):$(K8S_VERSION)
 TEST_CONTAINER_FILES=$(shell find tests/ -type f ! -name '*.created')
 


### PR DESCRIPTION
Increase K8s used for tests to [1.14.1] (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md )