### PR TITLE
Automated cherry pick of #243: runsvdir is not in the same location for different base

### DIFF
--- a/filesystem/sbin/start_runit
+++ b/filesystem/sbin/start_runit
@@ -13,4 +13,5 @@ fi
 # Export the nodename set by the startup procedure. 
 export NODENAME=$(cat /var/lib/calico/nodename)
 
-exec /usr/bin/runsvdir -P /etc/service/enabled
+RUNSVDIR=$(/usr/bin/which runsvdir)
+exec ${RUNSVDIR} -P /etc/service/enabled


### PR DESCRIPTION
Cherry pick of #243 on release-v3.7.

#243: runsvdir is not in the same location for different base

```release-note
Fix bad runsvdir location on non-amd64 architectures (@digaxfr)
```