### PR TITLE
release-v3.7: Update libcalico, confd, and felix pins

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7a0a9aab20ee4699e0db9c4bcfb365168ba52cf80e5c88c71911689ae7abeac4
-updated: 2019-04-23T18:28:51.45947138Z
+hash: ca2f91e0e8da270bda6ffbd36a43df0760c8528e346eaf39e7c8bcb33598302d
+updated: 2019-06-06T22:14:49.193503656Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -145,7 +145,7 @@ imports:
 - name: github.com/karrick/godirwalk
   version: 4e17292779dcc7ed08e10c03bfdd022f7c28b3c3
 - name: github.com/kelseyhightower/confd
-  version: ee4b81d5387320f60f3e622084f26398261cae8b
+  version: bb128d37900d58175854fcef9d9e42bace29e15c
   repo: https://github.com/projectcalico/confd.git
   subpackages:
   - pkg/backends
@@ -217,7 +217,7 @@ imports:
 - name: github.com/pkg/errors
   version: 27936f6d90f9c8e1145f11ed52ffffbfdb9e0af7
 - name: github.com/projectcalico/felix
-  version: 1dc2ef13deb11893547157c6ad1dfe571fbc049f
+  version: 516e82a1589d8e01c05d956fa7fecb0c94f7fbe3
   subpackages:
   - bpf
   - bpf/packrd
@@ -258,7 +258,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 6860ff2cfd923a870ff7a76563ce825d6e47adb8
+  version: 8898b03e9d624b38f903a530ffc40f8a39a433d9
   subpackages:
   - lib/apiconfig
   - lib/apis/v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,16 +9,16 @@ import:
   version: 773f5027234d0b08adf766be34f55df2f312abf7
 - package: github.com/kelseyhightower/confd
   repo: https://github.com/projectcalico/confd.git
-  version: ee4b81d5387320f60f3e622084f26398261cae8b
+  version: bb128d37900d58175854fcef9d9e42bace29e15c
   subpackages:
   - pkg/config
   - pkg/run
 - package: github.com/projectcalico/felix
-  version: 1dc2ef13deb11893547157c6ad1dfe571fbc049f
+  version: 516e82a1589d8e01c05d956fa7fecb0c94f7fbe3
   subpackages:
   - daemon
 - package: github.com/projectcalico/libcalico-go
-  version: 6860ff2cfd923a870ff7a76563ce825d6e47adb8
+  version: 8898b03e9d624b38f903a530ffc40f8a39a433d9
   subpackages:
   - lib/apiconfig
   - lib/apis/v3


### PR DESCRIPTION
## Description

```release-note
None required
```
