### PR TITLE
Fix issues where tunnel ip been reused incorrectly in kdd mode.

### DIFF
--- a/pkg/allocateip/allocateip.go
+++ b/pkg/allocateip/allocateip.go
@@ -142,8 +142,8 @@ func ensureHostTunnelAddress(ctx context.Context, c client.Interface, nodename s
 			// The tunnel address is not assigned, reassign it.
 			logCtx.WithField("currentAddr", addr).Info("Current address is not assigned, do not release and reassign")
 		} else {
-			// Failed to get assignment attributes, datastore issue possible, panic
-			logCtx.WithError(err).Fatalf("Failed to get assignment attributes for CIDR '%s'", addr)
+			// Failed to get assignment attributes, datastore connection issues possible, panic
+			logCtx.WithError(err).Panicf("Failed to get assignment attributes for CIDR '%s'", addr)
 		}
 	}
 

--- a/pkg/allocateip/allocateip.go
+++ b/pkg/allocateip/allocateip.go
@@ -21,11 +21,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	vxlanIPAMAttrString = "vxlanTunnelAddress"
-	ipipIPAMAttrString  = "ipipTunnelAddress"
-)
-
 // This file contains the main processing and common logic for assigning tunnel addresses,
 // used by calico/node to set the host's tunnel address if IPIP or VXLAN is enabled.
 // It will assign an address address if there are any available, and remove any tunnel address
@@ -105,10 +100,10 @@ func ensureHostTunnelAddress(ctx context.Context, c client.Interface, nodename s
 	var attrString string
 	if vxlan {
 		addr = node.Spec.IPv4VXLANTunnelAddr
-		attrString = vxlanIPAMAttrString
+		attrString = ipam.AttributeTypeVXLAN
 	} else if node.Spec.BGP != nil {
 		addr = node.Spec.BGP.IPv4IPIPTunnelAddr
-		attrString = ipipIPAMAttrString
+		attrString = ipam.AttributeTypeIPIP
 	}
 
 	// Work out if we need to assign a tunnel address.
@@ -174,10 +169,10 @@ func assignHostTunnelAddr(ctx context.Context, c client.Interface, nodename stri
 	attrs := map[string]string{ipam.AttributeNode: nodename}
 	var handle string
 	if vxlan {
-		attrs[ipam.AttributeType] = vxlanIPAMAttrString
+		attrs[ipam.AttributeType] = ipam.AttributeTypeVXLAN
 		handle = fmt.Sprintf("vxlan-tunnel-addr-%s", nodename)
 	} else {
-		attrs[ipam.AttributeType] = ipipIPAMAttrString
+		attrs[ipam.AttributeType] = ipam.AttributeTypeIPIP
 		handle = fmt.Sprintf("ipip-tunnel-addr-%s", nodename)
 	}
 	logCtx := getLogger(vxlan)

--- a/pkg/allocateip/allocateip_test.go
+++ b/pkg/allocateip/allocateip_test.go
@@ -290,7 +290,7 @@ var _ = allocateIPDescribe("ensureHostTunnelAddress", []string{"ipip", "vxlan"},
 
 	It("should panic on datastore errors", func() {
 		// Create a shimClient
-		pa := newIPPoolErrorAccessor(cerrors.ErrorDatastoreError{errors.New("mock datastore error"), nil})
+		pa := newIPPoolErrorAccessor(cerrors.ErrorDatastoreError{Err: errors.New("mock datastore error"), Identifier: nil})
 		cc := newShimClientWithPoolAccessor(c, be, pa)
 
 		node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")

--- a/pkg/allocateip/allocateip_test.go
+++ b/pkg/allocateip/allocateip_test.go
@@ -16,13 +16,16 @@ package allocateip
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	gnet "net"
 	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend"
@@ -30,9 +33,61 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
 )
 
-var _ = Describe("ensureHostTunnelAddress", func() {
+func allocateIPDescribe(description string, tunnelType []string, body func(tunnelType string)) bool {
+	for _, tt := range tunnelType {
+		switch tt {
+		case "ipip":
+			Describe(fmt.Sprintf("%s (ipip)", description),
+				func() {
+					body(tt)
+				})
+		case "vxlan":
+			Describe(fmt.Sprintf("%s (vxlan)", description),
+				func() {
+					body(tt)
+				})
+		default:
+			panic(errors.New(fmt.Sprintf("Unknown tunnelType, %s", tt)))
+		}
+	}
+
+	return true
+}
+
+func setTunnelAddressForNode(tunnelType string, n *api.Node, addr string) {
+	if tunnelType == "ipip" {
+		n.Spec.BGP.IPv4IPIPTunnelAddr = addr
+	} else if tunnelType == "vxlan" {
+		n.Spec.IPv4VXLANTunnelAddr = addr
+	} else {
+		panic(errors.New(fmt.Sprintf("Unknown tunnelType, %s", tunnelType)))
+	}
+}
+
+func checkTunnelAddressForNode(tunnelType string, n *api.Node, addr string) {
+	if tunnelType == "ipip" {
+		Expect(n.Spec.BGP.IPv4IPIPTunnelAddr).To(Equal(addr))
+	} else if tunnelType == "vxlan" {
+		Expect(n.Spec.IPv4VXLANTunnelAddr).To(Equal(addr))
+	} else {
+		panic(errors.New(fmt.Sprintf("Unknown tunnelType, %s", tunnelType)))
+	}
+}
+
+func checkIPAMAttr(tunnelType string, attr map[string]string) {
+	if tunnelType == "ipip" {
+		Expect(attr[ipam.AttributeType]).To(Equal(ipipIPAMAttrString))
+	} else if tunnelType == "vxlan" {
+		Expect(attr[ipam.AttributeType]).To(Equal(vxlanIPAMAttrString))
+	} else {
+		panic(errors.New(fmt.Sprintf("Unknown tunnelType, %s", tunnelType)))
+	}
+}
+
+var _ = allocateIPDescribe("ensureHostTunnelAddress", []string{"ipip", "vxlan"}, func(tunnelType string) {
 	log.SetOutput(os.Stdout)
 	// Set log formatting.
 	log.SetFormatter(&logutils.Formatter{})
@@ -42,6 +97,8 @@ var _ = Describe("ensureHostTunnelAddress", func() {
 	ctx := context.Background()
 	cfg, _ := apiconfig.LoadClientConfigFromEnvironment()
 
+	isVxlan := (tunnelType == "vxlan")
+
 	var c client.Interface
 	BeforeEach(func() {
 		// Clear out datastore
@@ -49,77 +106,123 @@ var _ = Describe("ensureHostTunnelAddress", func() {
 		Expect(err).ToNot(HaveOccurred())
 		be.Clean()
 
-		//create client and IPPool
+		//create client.
 		c, _ = client.New(*cfg)
-		c.IPPools().Create(ctx, makeIPv4Pool("172.16.0.0/24"), options.SetOptions{})
+
+		//create IPPool which has only two ips available.
+		_, err = c.IPPools().Create(ctx, makeIPv4Pool("172.16.0.0/31", 31), options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Pre-allocate a WEP ip on 172.16.0.0. This will force tunnel address to use 172.16.0.1
+		handle := "myhandle"
+		wepIp := gnet.IP{172, 16, 0, 0}
+		err = c.IPAM().AssignIP(ctx, ipam.AssignIPArgs{
+			IP:       net.IP{wepIp},
+			Hostname: "test.node",
+			HandleID: &handle,
+		})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("IPIP tunnel address tests", func() {
-		It("should add tunnel address to node", func() {
-			node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
-			node.Name = "test.node"
+	It("should add tunnel address to node", func() {
+		node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
+		node.Name = "test.node"
 
-			_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+		_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
-			_, ip4net, _ := net.ParseCIDR("172.16.0.0/24")
-			ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, false)
-			n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(n.Spec.BGP.IPv4IPIPTunnelAddr).ToNot(Equal(""))
-		})
-
-		It("should add tunnel address to node without BGP Spec", func() {
-			node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
-			node.Name = "test.node"
-			node.Spec.BGP = nil
-
-			_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			_, ip4net, _ := net.ParseCIDR("172.16.0.0/24")
-			ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, false)
-			n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(n.Spec.BGP).NotTo(BeNil())
-			Expect(n.Spec.BGP.IPv4IPIPTunnelAddr).ToNot(Equal(""))
-		})
+		_, ip4net, _ := net.ParseCIDR("172.16.0.0/31")
+		ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, isVxlan)
+		n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		checkTunnelAddressForNode(tunnelType, n, "172.16.0.1")
 	})
 
-	Context("VXLAN tunnel address tests", func() {
-		It("should add tunnel address to node", func() {
-			node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
-			node.Name = "test.node"
+	It("should add tunnel address to node without BGP Spec", func() {
+		node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
+		node.Name = "test.node"
+		node.Spec.BGP = nil
 
-			_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+		_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
-			_, ip4net, _ := net.ParseCIDR("172.16.0.0/24")
-			ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, true)
-			n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(n.Spec.IPv4VXLANTunnelAddr).ToNot(Equal(""))
-		})
+		_, ip4net, _ := net.ParseCIDR("172.16.0.0/31")
+		ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, isVxlan)
+		n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		checkTunnelAddressForNode(tunnelType, n, "172.16.0.1")
+	})
 
-		It("should add tunnel address to node without BGP Spec", func() {
-			node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
-			node.Name = "test.node"
-			node.Spec.BGP = nil
+	It("should assign new tunnel address to node on ippool update", func() {
+		node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
+		node.Name = "test.node"
+		setTunnelAddressForNode(tunnelType, node, "172.16.10.10")
 
-			_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+		_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
-			_, ip4net, _ := net.ParseCIDR("172.16.0.0/24")
-			ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, true)
-			n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(n.Spec.IPv4VXLANTunnelAddr).ToNot(Equal(""))
-		})
+		_, ip4net, _ := net.ParseCIDR("172.16.0.0/31")
+		ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, isVxlan)
+		n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		checkTunnelAddressForNode(tunnelType, n, "172.16.0.1")
+	})
 
+	It("should assign new tunnel address to node on pre-allocated address", func() {
+		node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
+		node.Name = "test.node"
+		setTunnelAddressForNode(tunnelType, node, "172.16.0.0")
+
+		_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, ip4net, _ := net.ParseCIDR("172.16.0.0/31")
+		ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, isVxlan)
+		n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		checkTunnelAddressForNode(tunnelType, n, "172.16.0.1")
+
+		// Verify 172.16.0.0 has not been released.
+		_, err = c.IPAM().GetAssignmentAttributes(ctx, net.IP{IP: gnet.ParseIP("172.16.0.0")})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should assign new tunnel address to node on unassigned address, and do nothing if node restart", func() {
+		node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
+		node.Name = "test.node"
+		setTunnelAddressForNode(tunnelType, node, "172.16.0.1")
+
+		_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify 172.16.0.1 is not properly assigned to tunnel address.
+		_, err = c.IPAM().GetAssignmentAttributes(ctx, net.IP{IP: gnet.ParseIP("172.16.0.1")})
+		Expect(err).To(HaveOccurred())
+
+		_, ip4net, _ := net.ParseCIDR("172.16.0.0/31")
+		ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, isVxlan)
+		n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		checkTunnelAddressForNode(tunnelType, n, "172.16.0.1")
+
+		// 172.16.0.1 is properly assigned to tunnel address.
+		attr, err := c.IPAM().GetAssignmentAttributes(ctx, net.IP{IP: gnet.ParseIP("172.16.0.1")})
+		Expect(err).NotTo(HaveOccurred())
+		checkIPAMAttr(tunnelType, attr)
+
+		// Now we have a wep IP allocated at 172.16.0.0 and tunnel ip allocated at 172.16.0.1.
+		// Release wep IP and call ensureHostTunnelAddress again. Tunnel ip should not be changed.
+		err = c.IPAM().ReleaseByHandle(ctx, "myhandle")
+		Expect(err).NotTo(HaveOccurred())
+
+		ensureHostTunnelAddress(ctx, c, node.Name, []net.IPNet{*ip4net}, isVxlan)
+		n, err = c.Nodes().Get(ctx, node.Name, options.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		checkTunnelAddressForNode(tunnelType, n, "172.16.0.1")
 	})
 })
 
-var _ = Describe("removeHostTunnelAddr", func() {
+var _ = allocateIPDescribe("removeHostTunnelAddress", []string{"ipip", "vxlan"}, func(tunnelType string) {
 	log.SetOutput(os.Stdout)
 	// Set log formatting.
 	log.SetFormatter(&logutils.Formatter{})
@@ -128,6 +231,8 @@ var _ = Describe("removeHostTunnelAddr", func() {
 
 	ctx := context.Background()
 	cfg, _ := apiconfig.LoadClientConfigFromEnvironment()
+
+	isVxlan := (tunnelType == "vxlan")
 
 	var c client.Interface
 	BeforeEach(func() {
@@ -138,67 +243,35 @@ var _ = Describe("removeHostTunnelAddr", func() {
 
 		//create client and IPPool
 		c, _ = client.New(*cfg)
-		c.IPPools().Create(ctx, makeIPv4Pool("172.16.0.0/24"), options.SetOptions{})
+		c.IPPools().Create(ctx, makeIPv4Pool("172.16.0.0/24", 26), options.SetOptions{})
 	})
 
-	Context("IPIP tunnel address tests", func() {
-		It("should remove tunnel address from node", func() {
-			node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
-			node.Name = "test.node"
-			node.Spec.BGP.IPv4IPIPTunnelAddr = "172.16.0.5"
+	It("should remove tunnel address from node", func() {
+		node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
+		node.Name = "test.node"
+		setTunnelAddressForNode(tunnelType, node, "172.16.0.5")
 
-			_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+		_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
-			removeHostTunnelAddr(ctx, c, node.Name, false)
-			n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(n.Spec.BGP.IPv4IPIPTunnelAddr).To(Equal(""))
-		})
-
-		It("should not panic on node without BGP Spec", func() {
-			node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
-			node.Name = "test.node"
-			node.Spec.BGP = nil
-
-			_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			removeHostTunnelAddr(ctx, c, node.Name, false)
-			n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(n.Spec.BGP).To(BeNil())
-		})
+		removeHostTunnelAddr(ctx, c, node.Name, isVxlan)
+		n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		checkTunnelAddressForNode(tunnelType, n, "")
 	})
 
-	Context("VXLAN tunnel address tests", func() {
-		It("should remove tunnel address from node", func() {
-			node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
-			node.Name = "test.node"
-			node.Spec.IPv4VXLANTunnelAddr = "172.16.0.5"
+	It("should not panic on node without BGP Spec", func() {
+		node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
+		node.Name = "test.node"
+		node.Spec.BGP = nil
 
-			_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+		_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
-			removeHostTunnelAddr(ctx, c, node.Name, true)
-			n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(n.Spec.IPv4VXLANTunnelAddr).To(Equal(""))
-		})
-
-		It("should not panic on node without BGP Spec", func() {
-			node := makeNode("192.168.0.1/24", "fdff:ffff:ffff:ffff:ffff::/80")
-			node.Name = "test.node"
-			node.Spec.BGP = nil
-
-			_, err := c.Nodes().Create(ctx, node, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			removeHostTunnelAddr(ctx, c, node.Name, true)
-			n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(n.Spec.BGP).To(BeNil())
-		})
+		removeHostTunnelAddr(ctx, c, node.Name, isVxlan)
+		n, err := c.Nodes().Get(ctx, node.Name, options.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n.Spec.BGP).To(BeNil())
 	})
 })
 

--- a/pkg/allocateip/allocateip_test.go
+++ b/pkg/allocateip/allocateip_test.go
@@ -24,16 +24,16 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	log "github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
 	"github.com/projectcalico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/options"
-	"github.com/projectcalico/libcalico-go/lib/ipam"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func allocateIPDescribe(description string, tunnelType []string, body func(tunnelType string)) bool {
@@ -117,7 +117,7 @@ var _ = allocateIPDescribe("ensureHostTunnelAddress", []string{"ipip", "vxlan"},
 		handle := "myhandle"
 		wepIp := gnet.IP{172, 16, 0, 0}
 		err = c.IPAM().AssignIP(ctx, ipam.AssignIPArgs{
-			IP:       net.IP{wepIp},
+			IP:       net.IP{IP: wepIp},
 			Hostname: "test.node",
 			HandleID: &handle,
 		})

--- a/pkg/allocateip/allocateip_test.go
+++ b/pkg/allocateip/allocateip_test.go
@@ -79,9 +79,9 @@ func checkTunnelAddressForNode(tunnelType string, n *api.Node, addr string) {
 
 func checkIPAMAttr(tunnelType string, attr map[string]string) {
 	if tunnelType == "ipip" {
-		Expect(attr[ipam.AttributeType]).To(Equal(ipipIPAMAttrString))
+		Expect(attr[ipam.AttributeType]).To(Equal(ipam.AttributeTypeIPIP))
 	} else if tunnelType == "vxlan" {
-		Expect(attr[ipam.AttributeType]).To(Equal(vxlanIPAMAttrString))
+		Expect(attr[ipam.AttributeType]).To(Equal(ipam.AttributeTypeVXLAN))
 	} else {
 		panic(errors.New(fmt.Sprintf("Unknown tunnelType, %s", tunnelType)))
 	}

--- a/pkg/allocateip/test_utils.go
+++ b/pkg/allocateip/test_utils.go
@@ -33,10 +33,10 @@ func makeNode(ipv4 string, ipv6 string) *api.Node {
 	return n
 }
 
-func makeIPv4Pool(ipv4cidr string, blockSize int) *api.IPPool {
+func makeIPv4Pool(name string, ipv4cidr string, blockSize int) *api.IPPool {
 	return &api.IPPool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "dont-care",
+			Name: name,
 		},
 		Spec: api.IPPoolSpec{
 			CIDR:        ipv4cidr,

--- a/pkg/allocateip/test_utils.go
+++ b/pkg/allocateip/test_utils.go
@@ -33,13 +33,14 @@ func makeNode(ipv4 string, ipv6 string) *api.Node {
 	return n
 }
 
-func makeIPv4Pool(ipv4cidr string) *api.IPPool {
+func makeIPv4Pool(ipv4cidr string, blockSize int) *api.IPPool {
 	return &api.IPPool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dont-care",
 		},
 		Spec: api.IPPoolSpec{
 			CIDR:        ipv4cidr,
+			BlockSize:   blockSize,
 			NATOutgoing: true,
 			IPIPMode:    api.IPIPModeAlways,
 		},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

In KDD mode, vxlan tunnel address is stored as a node annotation `projectcalico.org/IPv4VXLANTunnelAddr`. 

We could have an issue where 
- user `kubectl apply -f calico.yaml` and each node gets a vxlan tunnel address.
- user `kubectl delete -f calico.yaml` so all ipam CRDs has been deleted. However, vxlan address annotation remains.
- user `kubectl apply -f calico.yaml` again. ipam CRDs has been created again. Each node reuses stored vxlan address by startup script without actually allocate it in IPAM.

This PR fix this issue by checking if stored vxlan address has been claimed or not. If not, go reassign a new vxlan address and overwrite it in node annotation.

calico/node logs of rebooting calico/node, no reassignment. 
```
2019-06-15 15:26:56.185 [INFO][9] startup.go 181: Using node name: ip-172-16-101-168.us-west-2.compute.internal
2019-06-15 15:26:56.211 [INFO][18] k8s.go 228: Using Calico IPAM
CALICO_NETWORKING_BACKEND is vxlan - no need to run a BGP daemon
Calico node started successfully
```

calico/node logs of reinstalling calico, vxlan address been reassigned. 
```
2019-06-15 15:20:10.628 [INFO][9] startup.go 181: Using node name: ip-172-16-101-168.us-west-2.compute.internal
2019-06-15 15:20:10.656 [INFO][18] k8s.go 228: Using Calico IPAM
2019-06-15 15:20:10.712 [ERROR][18] ipam.go 1369: Error reading block 10.244.1.80/29: resource does not exist: IPAMBlock(10-244-1-80-29) with error: ipamblocks.crd.projectcalico.org "10-244-1-80-29" not found
2019-06-15 15:20:10.712 [INFO][18] allocateip.go 148: Assign new tunnel address IP="10.244.1.80" type="vxlanTunnelAddress"
2019-06-15 15:20:10.712 [INFO][18] ipam.go 87: Auto-assign 1 ipv4, 0 ipv6 addrs for host 'ip-172-16-101-168.us-west-2.compute.internal'
2019-06-15 15:20:10.717 [INFO][18] ipam.go 313: Looking up existing affinities for host handle="vxlan-tunnel-addr-ip-172-16-101-168.us-west-2.compute.internal" host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.720 [INFO][18] ipam.go 371: Ran out of existing affine blocks for host handle="vxlan-tunnel-addr-ip-172-16-101-168.us-west-2.compute.internal" host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.722 [INFO][18] ipam.go 436: No more affine blocks, but need to allocate 1 more addresses - allocate another block handle="vxlan-tunnel-addr-ip-172-16-101-168.us-west-2.compute.internal" host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.722 [INFO][18] ipam.go 440: Looking for an unclaimed block handle="vxlan-tunnel-addr-ip-172-16-101-168.us-west-2.compute.internal" host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.724 [INFO][18] ipam_block_reader_writer.go 114: Found free block: 10.244.1.80/29
2019-06-15 15:20:10.724 [INFO][18] ipam.go 452: Found unclaimed block host="ip-172-16-101-168.us-west-2.compute.internal" subnet=10.244.1.80/29
2019-06-15 15:20:10.724 [INFO][18] ipam_block_reader_writer.go 130: Trying to create affinity in pending state host="ip-172-16-101-168.us-west-2.compute.internal" subnet=10.244.1.80/29
2019-06-15 15:20:10.728 [INFO][18] ipam_block_reader_writer.go 160: Successfully created pending affinity for block host="ip-172-16-101-168.us-west-2.compute.internal" subnet=10.244.1.80/29
2019-06-15 15:20:10.728 [INFO][18] ipam.go 135: Attempting to load block cidr=10.244.1.80/29 host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.731 [INFO][18] ipam.go 140: The referenced block doesn't exist, trying to create it cidr=10.244.1.80/29 host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.734 [INFO][18] ipam.go 147: Wrote affinity as pending cidr=10.244.1.80/29 host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.736 [INFO][18] ipam.go 156: Attempting to claim the block cidr=10.244.1.80/29 host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.736 [INFO][18] ipam_block_reader_writer.go 183: Attempting to create a new block host="ip-172-16-101-168.us-west-2.compute.internal" subnet=10.244.1.80/29
2019-06-15 15:20:10.740 [INFO][18] ipam_block_reader_writer.go 224: Successfully created block
2019-06-15 15:20:10.740 [INFO][18] ipam_block_reader_writer.go 235: Confirming affinity host="ip-172-16-101-168.us-west-2.compute.internal" subnet=10.244.1.80/29
2019-06-15 15:20:10.744 [INFO][18] ipam_block_reader_writer.go 250: Successfully confirmed affinity host="ip-172-16-101-168.us-west-2.compute.internal" subnet=10.244.1.80/29
2019-06-15 15:20:10.744 [INFO][18] ipam.go 484: Claimed new block &{BlockKey(cidr=10.244.1.80/29) 0xc000445360 444997 0xc000652de0 0s} - assigning 1 addresses host="ip-172-16-101-168.us-west-2.compute.internal" subnet=10.244.1.80/29
2019-06-15 15:20:10.744 [INFO][18] ipam.go 804: Attempting to assign 1 addresses from block block=10.244.1.80/29 handle="vxlan-tunnel-addr-ip-172-16-101-168.us-west-2.compute.internal" host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.746 [INFO][18] ipam.go 1265: Creating new handle: vxlan-tunnel-addr-ip-172-16-101-168.us-west-2.compute.internal
2019-06-15 15:20:10.761 [INFO][18] ipam.go 827: Writing block in order to claim IPs block=10.244.1.80/29 handle="vxlan-tunnel-addr-ip-172-16-101-168.us-west-2.compute.internal" host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.770 [INFO][18] ipam.go 840: Successfully claimed IPs: [10.244.1.80/29] block=10.244.1.80/29 handle="vxlan-tunnel-addr-ip-172-16-101-168.us-west-2.compute.internal" host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.770 [INFO][18] ipam.go 569: Auto-assigned 1 out of 1 IPv4s: [10.244.1.80/29] handle="vxlan-tunnel-addr-ip-172-16-101-168.us-west-2.compute.internal" host="ip-172-16-101-168.us-west-2.compute.internal"
2019-06-15 15:20:10.806 [INFO][18] allocateip.go 228: Set tunnel address IP="10.244.1.80/29" type="vxlanTunnelAddress"
CALICO_NETWORKING_BACKEND is vxlan - no need to run a BGP daemon
Calico node started successfully
```


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
