### PR TITLE
Use iptables 1.8 with amd64 image

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -21,12 +21,6 @@ LABEL maintainer "Casey Davenport <casey@tigera.io>"
 
 ARG ARCH=amd64
 
-# Install a backported version of iptables to ensure we have version 1.6.2
-# Similarly for iproute2, we want a more recent version for BPF support.
-RUN printf "deb http://deb.debian.org/debian stretch-backports main\n" > /etc/apt/sources.list.d/backports.list \ 
-    && apt-get update \
-    && apt-get -t stretch-backports install -y iptables iproute2
-
 # Install remaining runtime deps required for felix from the global repository
 RUN apt-get update && apt-get install -y \
     ipset \
@@ -45,6 +39,20 @@ RUN apt-get update && apt-get install -y \
     # Also needed (provides utilities for browsing procfs like ps) 
     procps \    
     ca-certificates
+
+# Install iptables from buster to get version 1.8.2
+# Similarly for iproute2, we want a more recent version for BPF support.
+RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease
+RUN echo 'deb     http://ftp.de.debian.org/debian/    buster main contrib non-free' > /etc/apt/sources.list.d/buster.list
+RUN apt-get update && apt-get install -y -t buster \
+    ipset \
+    iptables \
+    iproute2
+
+# Set the iptables and ip6tables binaries to link to the legacy backend
+# version of the commands, by default they link to the nft backend.
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
+RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 # Copy our bird binaries in
 COPY --from=bird /bird* /bin/


### PR DESCRIPTION
## Description
Update amd64 image to use iptables 1.8


## Release Note

```release-note
Use iptables 1.8 with amd64.
```
