### PR TITLE
Enable VXLAN when VXLANMode is CrossSubnet

### DIFF
--- a/pkg/allocateip/allocateip.go
+++ b/pkg/allocateip/allocateip.go
@@ -331,7 +331,7 @@ func determineEnabledPoolCIDRs(node api.Node, ipPoolList api.IPPoolList, vxlan b
 
 		// Check if desired encap is enabled in the IP pool, the IP pool is not disabled, and it is IPv4 pool since we don't support encap with IPv6.
 		if vxlan {
-			if (ipPool.Spec.VXLANMode == api.VXLANModeAlways) && !ipPool.Spec.Disabled && poolCidr.Version() == 4 {
+			if (ipPool.Spec.VXLANMode == api.VXLANModeAlways || ipPool.Spec.VXLANMode == api.VXLANModeCrossSubnet) && !ipPool.Spec.Disabled && poolCidr.Version() == 4 {
 				cidrs = append(cidrs, *poolCidr)
 			}
 		} else {

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -774,6 +774,8 @@ func createIPPool(ctx context.Context, client client.Interface, cidr *cnet.IPNet
 	switch strings.ToLower(vxlanModeName) {
 	case "", "off", "never":
 		vxlanMode = api.VXLANModeNever
+	case "crosssubnet", "cross-subnet":
+		vxlanMode = api.VXLANModeCrossSubnet
 	case "always":
 		vxlanMode = api.VXLANModeAlways
 	default:


### PR DESCRIPTION
This should mimic the behaviour of when VXLANMode is Always

## Description
We would like to have a CrossSubnet option available for VXLAN that works much the same way the the CrossSubnet option works for IPIP. This PR tells node to recognise the CrossSubnet for VXLAN, and do what it does for the Always mode.
-->

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Might need release notes
```
