### PR TITLE
Fix scapy binary in ip spoofing

### DIFF
--- a/tests/k8st/tests/test_ipip_spoofing.py
+++ b/tests/k8st/tests/test_ipip_spoofing.py
@@ -179,7 +179,7 @@ class TestSpoof(TestBase):
     def send_packet(ns_name, name, remote_pod_ip, message):
         try:
             kubectl("exec " + name + " -ti -n %s -- "
-                                     "scapy << EOF\n"
+                                     "scapy3 << EOF\n"
                                      "send("
                                      "IP(dst='%s')/"
                                      "UDP(dport=5000, sport=5000)/"
@@ -194,7 +194,7 @@ class TestSpoof(TestBase):
     def send_spoofed_ipip_packet(ns_name, name, remote_node_ip, remote_pod_ip, message):
         try:
             kubectl("exec " + name + " -ti -n %s -- "
-                                     "scapy << EOF\n"
+                                     "scapy3 << EOF\n"
                                      "send("
                                      "IP(dst='%s')/"
                                      "IP(dst='%s')/"
@@ -210,7 +210,7 @@ class TestSpoof(TestBase):
     def send_spoofed_vxlan_packet(ns_name, name, remote_node_ip, remote_pod_ip, message):
         try:
             kubectl("exec " + name + " -ti -n %s -- "
-                                     "scapy << EOF\n"
+                                     "scapy3 << EOF\n"
                                      "send("
                                      "IP(dst='%s')/"
                                      "UDP(dport=4789)/"


### PR DESCRIPTION
The image we use for ip spoofing was updated a few days ago and I believe is the cause of broken CI tests. The image is https://hub.docker.com/r/ehlers/scapy.
I would have set a tag for the image but It does not have any tags so this may happen again.