### PR TITLE
Use BIRD code incorporating upstream v1.6.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ ifeq ($(LOCAL_BUILD),true)
 endif
 
 # Versions and location of dependencies used in the build.
-BIRD_VER?=v0.3.3-0-g1e8dd375
+BIRD_VER?=v0.3.3-138-ge37e4770
 BIRD_IMAGE ?= calico/bird:$(BIRD_VER)-$(ARCH)
 
 # Versions and locations of dependencies used in tests.


### PR DESCRIPTION
## Description
Use BIRD code incorporating upstream v1.6.7.  Specifically this gives us this option of using long-lived graceful restart in our BGP peering configs.  (Although note that actually making use of that will require further enhancements.)

The BIRD code update PR is at https://github.com/projectcalico/bird/pull/70.

## Release Note
```release-note
The bundled BIRD code has been updated so as to incorporate the upstream BIRD release v1.6.7.
```
