### PR TITLE
K8ST: Better code for DaemonSet update

### DIFF
--- a/tests/k8st/tests/test_bgp_advert.py
+++ b/tests/k8st/tests/test_bgp_advert.py
@@ -110,8 +110,7 @@ class _TestBGPAdvert(TestBase):
         # Enable debug logging
         self.update_ds_env("calico-node",
                            "kube-system",
-                           "BGP_LOGSEVERITYSCREEN",
-                           "debug")
+                           {"BGP_LOGSEVERITYSCREEN": "debug"})
 
         # Establish BGPPeer from cluster nodes to node-extra
         calicoctl("""apply -f - << EOF

--- a/tests/k8st/tests/test_bgp_advert_v6.py
+++ b/tests/k8st/tests/test_bgp_advert_v6.py
@@ -110,8 +110,7 @@ class _TestBGPAdvertV6(TestBaseV6):
         # Enable debug logging
         self.update_ds_env("calico-node",
                            "kube-system",
-                           "BGP_LOGSEVERITYSCREEN",
-                           "debug")
+                           {"BGP_LOGSEVERITYSCREEN": "debug"})
 
         # Establish BGPPeer from cluster nodes to node-extra
         calicoctl("""apply -f - << EOF


### PR DESCRIPTION
This PR improves the K8ST update_ds_env function so that it can change
more than one environment variable, in the calico-node DaemonSet, at
once.  We don't strictly need it now, as we have stopped setting the
CALICO_ADVERTISE_CLUSTER_IPS variable, but I believe it's a useful
capability and would be a shame to throw away.

Following is my previous commit message from when I worked on this in
September 2010:

We've been seeing flakiness in this area in Semaphore test runs.
Specifically:

- when `TestBGPAdvert.test_mainline` runs on Semaphore, it appears to
hang for a long time here, and sometimes the whole test run is timed
out

- when I've enabled it, logging shows that the DaemonSet updates seem
to take a long time, with logging like this:

```
    2019-09-09 10:29:34,636 INFO [2019-09-09 10:29:34.636901] docker exec kube-node-extra service bird restart
    2019-09-09 10:29:34,729 INFO Output:

    2019-09-09 10:29:44,765 INFO 3/3 nodes updated
    2019-09-09 10:29:54,808 INFO 1/3 nodes updated
    2019-09-09 10:30:04,826 INFO 1/3 nodes updated
    2019-09-09 10:30:14,845 INFO 1/3 nodes updated
    2019-09-09 10:30:24,862 INFO 1/3 nodes updated
    2019-09-09 10:30:34,881 INFO 1/3 nodes updated
    2019-09-09 10:30:44,899 INFO 1/3 nodes updated
    2019-09-09 10:30:54,917 INFO 1/3 nodes updated
    2019-09-09 10:31:04,935 INFO 1/3 nodes updated
    2019-09-09 10:31:14,961 INFO 1/3 nodes updated
    2019-09-09 10:31:24,986 INFO 1/3 nodes updated
    ...
```

I wondered if it could be problematic to make two updates so quickly
to the same DaemonSet.  Anyway, it feels lazy, so I looked at changing
the code to set both of the variables that we need in a single
update.  The obvious change here unexpectedly raised an error, and I
eventually concluded that

    container.env.append({"name": k, "value": v, "value_from": None})

was wrong, and should be

    v1_ev = client.V1EnvVar(name=k, value=v, value_from=None)
    container.env.append(v1_ev)

I haven't worked out for sure if the previous form ever worked, and if
so why.  (Perhaps there is some special casing to allow the plain dict
as well as a V1EnvVar?  Perhaps one of the Python packages that we use
has been revved?)

Anyway, the new code is definitely better, by correctly using a
V1EnvVar, and by setting both variables in a single DaemonSet update.
Let's see if it helps with the observed flakiness.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
