### PR TITLE
Add semaphore.yml

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,15 @@
+version: v1.0
+name: node
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Run k8s-tests
+    task:
+      jobs:
+      - name: Download code and run tests
+        commands:
+          # Checkout the code and run the Kubernetes tests.
+          - checkout
+          - make k8s-test


### PR DESCRIPTION
Use Semaphore v2 to run the K8ST test, as that test suite requires resources that are on the edge of what Semaphore v1 can provide.