### PR TITLE
Fix local build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,18 +170,6 @@ endif
 
 EXTRA_DOCKER_ARGS += -v $(GOMOD_CACHE):/go/pkg/mod:rw
 
-DOCKER_RUN := mkdir -p .go-pkg-cache $(GOMOD_CACHE) && \
-        docker run --rm \
-                --net=host \
-                $(EXTRA_DOCKER_ARGS) \
-                -e LOCAL_USER_ID=$(LOCAL_USER_ID) \
-                -e GOCACHE=/go-cache \
-                -e GOARCH=$(ARCH) \
-                -e GOPATH=/go \
-                -v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
-                -v $(CURDIR)/.go-pkg-cache:/go-cache:rw \
-                -w /go/src/$(PACKAGE_NAME)
-
 # Build mounts for running in "local build" mode. This allows an easy build using local development code,
 # assuming that there is a local checkout of libcalico in the same directory as this repo.
 PHONY:local_build
@@ -206,6 +194,19 @@ endif
 ifeq ($(LOCAL_BUILD),true)
 .PHONY: $(SRC_FILES)
 endif
+
+DOCKER_RUN := mkdir -p .go-pkg-cache $(GOMOD_CACHE) && \
+        docker run --rm \
+                --net=host \
+                $(EXTRA_DOCKER_ARGS) \
+                -e LOCAL_USER_ID=$(LOCAL_USER_ID) \
+                -e GOCACHE=/go-cache \
+                -e GOARCH=$(ARCH) \
+                -e GOPATH=/go \
+                -v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
+                -v $(CURDIR)/.go-pkg-cache:/go-cache:rw \
+                -w /go/src/$(PACKAGE_NAME)
+
 
 ## Clean enough that a new release build will be clean
 clean:


### PR DESCRIPTION
## Description

Tried to build a test image when looking in to #429 and found setting `LOCAL_BUILD` didn't result in a working build. This turned out to be because `EXTRA_DOCKER_ARGS` is modified after `DOCKER_RUN` is defined. Don't know if this works for some versions of make but it doesn't work for GNU Make 3.81 on macOS.

Attached patch defines `DOCKER_RUN` after the local build code has set `EXTRA_DOCKER_ARGS`, which fixes the build.
 
## Todos

Just a fix to dev tooling so I don't think these apply?

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
