### PR TITLE
Enable node to update CNI kubeconfig as needed

### DIFF
--- a/cmd/calico-node/main.go
+++ b/cmd/calico-node/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/projectcalico/node/buildinfo"
 	"github.com/projectcalico/node/pkg/allocateip"
+	"github.com/projectcalico/node/pkg/cni"
 	"github.com/projectcalico/node/pkg/health"
 	"github.com/projectcalico/node/pkg/startup"
 
@@ -40,6 +41,7 @@ var version = flagSet.Bool("v", false, "Display version")
 var runFelix = flagSet.Bool("felix", false, "Run Felix")
 var runStartup = flagSet.Bool("startup", false, "Initialize a new node")
 var allocateTunnelAddrs = flagSet.Bool("allocate-tunnel-addrs", false, "Configure tunnel addresses for this node")
+var monitorToken = flagSet.Bool("monitor-token", false, "Watch for Kubernetes token changes, update CNI config")
 
 // Options for liveness checks.
 var felixLive = flagSet.Bool("felix-live", false, "Run felix liveness checks")
@@ -111,6 +113,8 @@ func main() {
 		confd.Run(cfg)
 	} else if *allocateTunnelAddrs {
 		allocateip.Run()
+	} else if *monitorToken {
+		cni.Run()
 	} else {
 		fmt.Println("No valid options provided. Usage:")
 		flagSet.PrintDefaults()

--- a/filesystem/etc/rc.local
+++ b/filesystem/etc/rc.local
@@ -61,12 +61,18 @@ case "$CALICO_NETWORKING_BACKEND" in
 	;;
 esac
 
+if [ "$CALICO_MANAGE_CNI" = "true" ]; then
+	# Enable management of the CNI configuration.
+	cp -a /etc/service/available/cni  /etc/service/enabled/
+fi
+
 if [ "$CALICO_DISABLE_FILE_LOGGING" = "true" ]; then
 	rm -rf /etc/service/enabled/bird/log
 	rm -rf /etc/service/enabled/bird6/log
 	rm -rf /etc/service/enabled/confd/log
 	rm -rf /etc/service/enabled/felix/log
 	rm -rf /etc/service/enabled/calico-bgp-daemon/log
+	rm -rf /etc/service/enabled/cni/log
 fi
 
 echo "Calico node started successfully"

--- a/filesystem/etc/service/available/cni/log/run
+++ b/filesystem/etc/service/available/cni/log/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+LOGDIR=/var/log/calico/cni
+mkdir -p $LOGDIR
+exec svlogd $LOGDIR

--- a/filesystem/etc/service/available/cni/run
+++ b/filesystem/etc/service/available/cni/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec calico-node -monitor-token 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/projectcalico/libcalico-go v0.0.0-20191008172221-1ba69f71d8c4
 	github.com/sirupsen/logrus v1.4.2
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
+	gopkg.in/fsnotify/fsnotify.v1 v1.4.7
 	k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/fsnotify/fsnotify.v1 v1.4.7 h1:XNNYLJHt73EyYiCZi6+xjupS9CpvmiDgjPTAjrBlQbo=
+gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 h1:OAj3g0cR6Dx/R07QgQe8wkA9RNjB2u4i700xBkIT4e0=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=

--- a/pkg/cni/token_watch.go
+++ b/pkg/cni/token_watch.go
@@ -1,0 +1,103 @@
+package cni
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/fsnotify/fsnotify.v1"
+	"k8s.io/client-go/rest"
+)
+
+var serviceaccountDirectory string = "/var/run/secrets/kubernetes.io/serviceaccount/"
+var kubeconfigPath string = "/host/etc/cni/net.d/calico-kubeconfig"
+
+func Run() {
+	// Log to stdout.  this prevents our logs from being interpreted as errors by, for example,
+	// fluentd's default configuration.
+	logrus.SetOutput(os.Stdout)
+
+	// Create a watcher for file changes.
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		panic(err)
+	}
+	defer watcher.Close()
+
+	// Watch for changes to the serviceaccount directory. Rety if necessary.
+	for {
+		if err := watcher.Add(serviceaccountDirectory); err != nil {
+			// Error watching the file - retry
+			logrus.WithError(err).Error("Failed to watch Kubernetes serviceaccount files.")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		// Successfully watched the file. Break from the retry loop.
+		logrus.WithField("directory", serviceaccountDirectory).Info("Watching contents for changes.")
+		break
+	}
+
+	// Handle events from the watcher.
+	for {
+		// To prevent tight looping, add a sleep here.
+		time.Sleep(1 * time.Second)
+
+		select {
+		case event := <-watcher.Events:
+			// We've received a notification that the Kubernetes secrets files have changed.
+			// Update the kubeconfig file on disk to match.
+			logrus.WithField("event", event).Info("Notified of change to serviceaccount files.")
+			cfg, err := rest.InClusterConfig()
+			if err != nil {
+				logrus.WithError(err).Error("Error generating kube config.")
+				continue
+			}
+			err = rest.LoadTLSFiles(cfg)
+			if err != nil {
+				logrus.WithError(err).Error("Error loading TLS files.")
+				continue
+			}
+			writeKubeconfig(cfg)
+
+		case err := <-watcher.Errors:
+			// We've received an error - log it out but don't exit.
+			logrus.WithError(err).Error("Error watching serviceaccount files.")
+		}
+	}
+}
+
+// writeKubeconfig writes an updated kubeconfig file to disk that the CNI plugin can use to access the Kubernetes API.
+func writeKubeconfig(cfg *rest.Config) {
+	template := `# Kubeconfig file for Calico CNI plugin. Installed by calico/node.
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: %s
+    certificate-authority-data: "%s"
+users:
+- name: calico
+  user:
+    token: %s
+contexts:
+- name: calico-context
+  context:
+    cluster: local
+    user: calico
+current-context: calico-context`
+
+	// Replace the placeholders.
+	data := fmt.Sprintf(template, cfg.Host, string(base64.StdEncoding.EncodeToString(cfg.CAData)), cfg.BearerToken)
+
+	// Write the filled out config to disk.
+	if err := ioutil.WriteFile(kubeconfigPath, []byte(data), 0600); err != nil {
+		logrus.WithError(err).Error("Failed to write CNI plugin kubeconfig file")
+		return
+	}
+	logrus.WithField("path", kubeconfigPath).Info("Wrote updated CNI kubeconfig file.")
+}


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

When using projected serviceaccount tokens, the kubelet will rotate the token file periodically. This invalidates the one in use by the Calico CNI plugin.

This PR enabled node to detect when the token has changed, and update the CNI plugin's kubeconfig file with the new information in response so long as the following is true:

- CALICO_MANAGE_CNI is set
- The CNI network directory is mounted into calico/node. 


- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
calico/node now updates CNI kubeconfig when credentials change
```