### PR TITLE
K8ST: Work around unavailability of Docker repo

### DIFF
--- a/tests/k8st/utils/utils.py
+++ b/tests/k8st/utils/utils.py
@@ -71,8 +71,8 @@ def start_external_node_with_bgp(name, config):
             time.sleep(20)
 
     # Install bird on extra node
-    run("docker exec %s apt update" % name)
-    run("docker exec %s apt install -y bird" % name)
+    run("docker exec %s apt-get update --fix-missing" % name)
+    run("docker exec %s apt-get install -y bird" % name)
     run("docker exec %s mkdir /run/bird" % name)
     with open('bird.conf', 'w') as birdconfig:
         birdconfig.write(config)


### PR DESCRIPTION
The kubeadm-dind-cluster image that we use in K8ST has a Docker repo
in its APT sources, and it appears that that Docker repo is now
unavailable, which causes an "apt update" to fail and scupper the
whole test.

We don't actually need any updates from that repo, so add
--fix-missing to work around that.  Also change apt to apt-get, as
that's best practice for scripting.
