### PR TITLE
[release-v3.8] BoundServiceAccountToken volume support

### DIFF
--- a/cmd/calico-node/main.go
+++ b/cmd/calico-node/main.go
@@ -24,6 +24,7 @@ import (
 	felix "github.com/projectcalico/felix/daemon"
 
 	"github.com/projectcalico/node/pkg/allocateip"
+	"github.com/projectcalico/node/pkg/cni"
 	"github.com/projectcalico/node/pkg/readiness"
 	"github.com/projectcalico/node/pkg/startup"
 
@@ -39,6 +40,7 @@ var version = flagSet.Bool("v", false, "Display version")
 var runFelix = flagSet.Bool("felix", false, "Run Felix")
 var runStartup = flagSet.Bool("startup", false, "Initialize a new node")
 var allocateTunnelAddrs = flagSet.Bool("allocate-tunnel-addrs", false, "Configure tunnel addresses for this node")
+var monitorToken = flagSet.Bool("monitor-token", false, "Watch for Kubernetes token changes, update CNI config")
 
 // Options for readiness checks.
 var birdReady = flagSet.Bool("bird-ready", false, "Run BIRD readiness checks")
@@ -107,6 +109,8 @@ func main() {
 		confd.Run(cfg)
 	} else if *allocateTunnelAddrs {
 		allocateip.Run()
+	} else if *monitorToken {
+		cni.Run()
 	} else {
 		fmt.Println("No valid options provided. Usage:")
 		flagSet.PrintDefaults()

--- a/filesystem/etc/rc.local
+++ b/filesystem/etc/rc.local
@@ -61,11 +61,9 @@ case "$CALICO_NETWORKING_BACKEND" in
 	;;
 esac
 
-# If running libnetwork plugin in a separate container, CALICO_LIBNETWORK_ENABLED would be false.
-# CALICO_LIBNETWORK_ENABLED is "false" by default. It can be set by passing `--libnetwork` flag while starting the calico/node via calicoctl
-if [ "$CALICO_LIBNETWORK_ENABLED" = "true" ]; then
-	echo "Starting libnetwork service"
-	cp -a /etc/service/available/libnetwork  /etc/service/enabled/
+if [ "$CALICO_MANAGE_CNI" = "true" ]; then
+	# Enable management of the CNI configuration.
+	cp -a /etc/service/available/cni  /etc/service/enabled/
 fi
 
 if [ "$CALICO_DISABLE_FILE_LOGGING" = "true" ]; then
@@ -75,6 +73,7 @@ if [ "$CALICO_DISABLE_FILE_LOGGING" = "true" ]; then
 	rm -rf /etc/service/enabled/felix/log
 	rm -rf /etc/service/enabled/libnetwork/log
 	rm -rf /etc/service/enabled/calico-bgp-daemon/log
+	rm -rf /etc/service/enabled/cni/log
 fi
 
 echo "Calico node started successfully"

--- a/filesystem/etc/service/available/cni/log/run
+++ b/filesystem/etc/service/available/cni/log/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+LOGDIR=/var/log/calico/cni
+mkdir -p $LOGDIR
+exec svlogd $LOGDIR

--- a/filesystem/etc/service/available/cni/run
+++ b/filesystem/etc/service/available/cni/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec calico-node -monitor-token 

--- a/glide.lock
+++ b/glide.lock
@@ -1,20 +1,21 @@
-hash: 53d5fe91310d940dc557772db2384bd173dc61a09c5da4558fff1e04b5eb73f6
-updated: 2019-08-09T15:31:38.404035-07:00
+hash: 13f8e016ba6001f5b37b9f957f0c8f782c2559ba8707067dfc067fea9e5542ca
+updated: 2019-10-11T00:15:03.49700612Z
 imports:
 - name: cloud.google.com/go
-  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
+  version: 0ebda48a7f143b1cce9eb37a8c1106ac762a3430
   subpackages:
   - compute/metadata
-  - internal
 - name: github.com/Azure/go-autorest
-  version: 1ff28809256a84bb6966640ff3d0371af82ccba4
+  version: 1ffcc8896ef6dfe022d90a4317d866f925cf0f9e
   subpackages:
   - autorest
   - autorest/adal
   - autorest/azure
   - autorest/date
+  - logger
+  - version
 - name: github.com/beorn7/perks
-  version: 4b2b341e8d7715fae06375aa633dbb6e91b3fb46
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
   - quantile
 - name: github.com/BurntSushi/toml
@@ -39,30 +40,26 @@ imports:
   subpackages:
   - semver
 - name: github.com/davecgh/go-spew
-  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/dgrijalva/jwt-go
   version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
-- name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: 3be5ad479f69d4e08d7fe25edf79bf3346bd658e
+  version: 8659100d2d9ecf3760a41838b1886db49426d001
 - name: github.com/go-playground/locales
-  version: f63010822830b6fe52288ee52d5a1151088ce039
+  version: 630ebbb602847eba93e75ae38bbc7bb7abcf1ff3
   subpackages:
   - currency
 - name: github.com/go-playground/universal-translator
   version: 71201497bace774495daed26a3874fd339e0b538
 - name: github.com/gogo/protobuf
-  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
   - gogoproto
   - proto
   - protoc-gen-gogo/descriptor
   - sortkeys
-- name: github.com/golang/glog
-  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
   version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
@@ -71,10 +68,18 @@ imports:
   - ptypes/any
   - ptypes/duration
   - ptypes/timestamp
-- name: github.com/google/btree
-  version: 7d79101e329e5a3adf994758c578dab82b90c017
+- name: github.com/google/go-cmp
+  version: 6f77996f0c42f7b84e5a2b252227263f93432e9b
+  subpackages:
+  - cmp
+  - cmp/internal/diff
+  - cmp/internal/flags
+  - cmp/internal/function
+  - cmp/internal/value
 - name: github.com/google/gofuzz
-  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+  version: 24818f796faf91cd76ec7bddd72458fbced7a6c1
+- name: github.com/google/uuid
+  version: d460ce9f8df2e77fb1ba55ca87fafed96c607494
 - name: github.com/googleapis/gnostic
   version: 0c5108395e2debce0d731cf0287ddf7242066aba
   subpackages:
@@ -82,7 +87,7 @@ imports:
   - compiler
   - extensions
 - name: github.com/gophercloud/gophercloud
-  version: 781450b3c4fcb4f5182bcc5133adb4b2e4a09d1d
+  version: c818fa66e4c88b30db28038fe3f18f2f4a0db9a8
   subpackages:
   - openstack
   - openstack/identity/v2/tenants
@@ -90,14 +95,10 @@ imports:
   - openstack/identity/v3/tokens
   - openstack/utils
   - pagination
-- name: github.com/gregjones/httpcache
-  version: 787624de3eb7bd915c329cba748687a3b22666a6
-  subpackages:
-  - diskcache
 - name: github.com/hashicorp/go-version
   version: ac23dc3fea5d1a983c43f6a0f6e2c13f0195d8bd
 - name: github.com/hashicorp/golang-lru
-  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  version: 20f1fb78b0740ba8c3cb143a61e86ba5c8669768
   subpackages:
   - simplelru
 - name: github.com/hpcloud/tail
@@ -108,13 +109,13 @@ imports:
   - watch
   - winfile
 - name: github.com/imdario/mergo
-  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
+  version: 9316a62528ac99aaecb4e47eadd6dc8aa6533d58
 - name: github.com/json-iterator/go
   version: f2b4162afba35581b6d4a50d3b8f34e33c144682
 - name: github.com/kardianos/osext
   version: 2bc1f35cddc0cc527b4bc3dce8578fc2a6c11384
 - name: github.com/kelseyhightower/confd
-  version: cfc051c4a6a476bc5f6bdc13540868e6c0f9bf72
+  version: 0c53cc8c429b6b2d2ccbf49dec6b8205556ba9eb
   repo: https://github.com/projectcalico/confd.git
   subpackages:
   - pkg/backends
@@ -125,13 +126,13 @@ imports:
   - pkg/resource/template
   - pkg/run
 - name: github.com/kelseyhightower/envconfig
-  version: dd1402a4d99de9ac2f396cd6fcb957bc2c695ec1
+  version: 0b417c4ec4a8a82eecc22a1459a504aa55163d61
 - name: github.com/kelseyhightower/memkv
   version: 892bfd468afa0fa476556e7bd7734a087cda08b3
 - name: github.com/leodido/go-urn
   version: a67a23e1c1af3c66528573bb86a87246477277c1
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: c182affec369e30f25d3eb8cd8a478dee585ae7d
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/mipearson/rfw
@@ -139,9 +140,9 @@ imports:
 - name: github.com/modern-go/concurrent
   version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
 - name: github.com/modern-go/reflect2
-  version: 05fbef0ca5da472bbf96c9322b84a53edc03c9fd
+  version: 94122c33edd36123c84d5368cfb2b69df93a0ec8
 - name: github.com/onsi/ginkgo
-  version: eea6ad008b96acdaa524f5b409513bf062b500ad
+  version: 72b6ab036f78c4bf1a9748c3941dd7c3de54917a
   subpackages:
   - config
   - extensions/table
@@ -162,7 +163,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: 90e289841c1ed79b7a598a7cd9959750cb5e89e2
+  version: bdebf9e0ece900259084cfa4121b97ce1a540939
   subpackages:
   - format
   - internal/assertion
@@ -175,12 +176,8 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
-- name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
-- name: github.com/peterbourgon/diskv
-  version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/projectcalico/felix
-  version: 17cd9f5b5ce32ad93e713d1e17359676de45023c
+  version: f57a408321fdb535ea6e98cfef9181d25491aefa
   subpackages:
   - bpf
   - buildinfo
@@ -220,7 +217,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: ac36d966132f2019eb4afc4d3823ed2a98564d2f
+  version: 896f59d614d5c47df94d47a78b1c01a909077bd7
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -271,7 +268,7 @@ imports:
   subpackages:
   - binder
 - name: github.com/projectcalico/typha
-  version: 9e1d78883c8afd0f089a52cb493ea691de60b4ae
+  version: 2fa03f68cfcca2c4f686dc4c2ee55792405ad4de
   subpackages:
   - pkg/config
   - pkg/logutils
@@ -314,28 +311,27 @@ imports:
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 13995c7128ccc8e51e9a6bd2b551020a27180abd
+  version: 54f0e4339ce73702a0607f49922aaa1e749b418d
 - name: golang.org/x/crypto
-  version: 49796115aa4b964c318aad4f3084fdb41e9aa067
+  version: e84da0312774c21d64ee2317962ef669b27ffb41
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  version: 65e2d4e15006aab9813ff8769e768bbf4bb667a0
   subpackages:
   - context
   - context/ctxhttp
   - html
   - html/atom
   - html/charset
+  - http/httpguts
   - http2
   - http2/hpack
   - idna
   - internal/timeseries
-  - lex/httplex
   - trace
-  - websocket
 - name: golang.org/x/oauth2
-  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
+  version: 9f3314589c9a9136388751d9adae6b0ed400978a
   subpackages:
   - google
   - internal
@@ -347,7 +343,7 @@ imports:
   - unix
   - windows
 - name: golang.org/x/text
-  version: b19bf474d317b857955b12035d2c5acb57ce8b01
+  version: e6919f6577db79269a6443b9dc46d18f2238fb5d
   subpackages:
   - encoding
   - encoding/charmap
@@ -359,6 +355,8 @@ imports:
   - encoding/simplifiedchinese
   - encoding/traditionalchinese
   - encoding/unicode
+  - internal/language
+  - internal/language/compact
   - internal/tag
   - internal/utf8internal
   - language
@@ -408,41 +406,48 @@ imports:
   - tap
   - transport
 - name: gopkg.in/fsnotify.v1
-  version: 7be54206639f256967dd82fa767397ba5f8f48f5
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: gopkg.in/go-playground/validator.v9
-  version: 46b4b1e301c24cac870ffcb4ba5c8a703d1ef475
+  version: 556b9da3c05f2a935bc086fb5a0bb55dd8112d2d
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tomb.v1
-  version: c131134a1947e9afd9cecfe11f4c6dff0732ae58
+  version: dd632973f1e7218eb1089048e0798ec9ae7dceb8
 - name: gopkg.in/yaml.v2
-  version: 670d4cfef0544295bc27a114dbac37980d83185a
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 - name: k8s.io/api
-  version: 072894a440bdee3a891dea811fe42902311cd2a3
+  version: 7cf5895f2711098d7d9527db0a4a49fb0dff7de2
   subpackages:
-  - admissionregistration/v1alpha1
   - admissionregistration/v1beta1
   - apps/v1
   - apps/v1beta1
   - apps/v1beta2
+  - auditregistration/v1alpha1
   - authentication/v1
   - authentication/v1beta1
   - authorization/v1
   - authorization/v1beta1
   - autoscaling/v1
   - autoscaling/v2beta1
+  - autoscaling/v2beta2
   - batch/v1
   - batch/v1beta1
   - batch/v2alpha1
   - certificates/v1beta1
+  - coordination/v1
+  - coordination/v1beta1
   - core/v1
   - events/v1beta1
   - extensions/v1beta1
   - networking/v1
+  - networking/v1beta1
+  - node/v1alpha1
+  - node/v1beta1
   - policy/v1beta1
   - rbac/v1
   - rbac/v1alpha1
   - rbac/v1beta1
+  - scheduling/v1
   - scheduling/v1alpha1
   - scheduling/v1beta1
   - settings/v1alpha1
@@ -450,7 +455,7 @@ imports:
   - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 103fd098999dc9c0c88536f5c9ad2e5da39373ae
+  version: 1799e75a07195de9460b8ef7300883499f12127b
   subpackages:
   - pkg/api/errors
   - pkg/api/meta
@@ -480,6 +485,7 @@ imports:
   - pkg/util/framer
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/naming
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
@@ -492,34 +498,41 @@ imports:
   - pkg/watch
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 7d04d0e2a0a1a4d4a1cd6baa432a2301492e4e65
+  version: 78d2af792babf2dd937ba2e2a8d99c753a5eda89
   subpackages:
   - discovery
   - kubernetes
   - kubernetes/scheme
-  - kubernetes/typed/admissionregistration/v1alpha1
   - kubernetes/typed/admissionregistration/v1beta1
   - kubernetes/typed/apps/v1
   - kubernetes/typed/apps/v1beta1
   - kubernetes/typed/apps/v1beta2
+  - kubernetes/typed/auditregistration/v1alpha1
   - kubernetes/typed/authentication/v1
   - kubernetes/typed/authentication/v1beta1
   - kubernetes/typed/authorization/v1
   - kubernetes/typed/authorization/v1beta1
   - kubernetes/typed/autoscaling/v1
   - kubernetes/typed/autoscaling/v2beta1
+  - kubernetes/typed/autoscaling/v2beta2
   - kubernetes/typed/batch/v1
   - kubernetes/typed/batch/v1beta1
   - kubernetes/typed/batch/v2alpha1
   - kubernetes/typed/certificates/v1beta1
+  - kubernetes/typed/coordination/v1
+  - kubernetes/typed/coordination/v1beta1
   - kubernetes/typed/core/v1
   - kubernetes/typed/events/v1beta1
   - kubernetes/typed/extensions/v1beta1
   - kubernetes/typed/networking/v1
+  - kubernetes/typed/networking/v1beta1
+  - kubernetes/typed/node/v1alpha1
+  - kubernetes/typed/node/v1beta1
   - kubernetes/typed/policy/v1beta1
   - kubernetes/typed/rbac/v1
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/scheduling/v1
   - kubernetes/typed/scheduling/v1alpha1
   - kubernetes/typed/scheduling/v1beta1
   - kubernetes/typed/settings/v1alpha1
@@ -549,12 +562,21 @@ imports:
   - tools/pager
   - tools/reference
   - transport
-  - util/buffer
   - util/cert
   - util/connrotation
   - util/flowcontrol
   - util/homedir
-  - util/integer
   - util/jsonpath
+  - util/keyutil
   - util/retry
+- name: k8s.io/klog
+  version: 89e63fd5117f8c20208186ef85f096703a280c20
+- name: k8s.io/utils
+  version: c2654d5206da6b7b6ace12841e8f359bb89b443c
+  subpackages:
+  - buffer
+  - integer
+  - trace
+- name: sigs.k8s.io/yaml
+  version: fd68e9863619f6ec2fdd8625fe1f02e7c877e480
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 13f8e016ba6001f5b37b9f957f0c8f782c2559ba8707067dfc067fea9e5542ca
-updated: 2019-10-11T00:15:03.49700612Z
+updated: 2019-10-10T18:02:24.740453292-07:00
 imports:
 - name: cloud.google.com/go
   version: 0ebda48a7f143b1cce9eb37a8c1106ac762a3430
@@ -406,6 +406,8 @@ imports:
   - tap
   - transport
 - name: gopkg.in/fsnotify.v1
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
+- name: gopkg.in/fsnotify/fsnotify.v1
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: gopkg.in/go-playground/validator.v9
   version: 556b9da3c05f2a935bc086fb5a0bb55dd8112d2d

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,16 +9,16 @@ import:
   version: 773f5027234d0b08adf766be34f55df2f312abf7
 - package: github.com/kelseyhightower/confd
   repo: https://github.com/projectcalico/confd.git
-  version: cfc051c4a6a476bc5f6bdc13540868e6c0f9bf72
+  version: 0c53cc8c429b6b2d2ccbf49dec6b8205556ba9eb
   subpackages:
   - pkg/config
   - pkg/run
 - package: github.com/projectcalico/felix
-  version: 17cd9f5b5ce32ad93e713d1e17359676de45023c
+  version: f57a408321fdb535ea6e98cfef9181d25491aefa
   subpackages:
   - daemon
 - package: github.com/projectcalico/libcalico-go
-  version: ac36d966132f2019eb4afc4d3823ed2a98564d2f
+  version: 896f59d614d5c47df94d47a78b1c01a909077bd7
   subpackages:
   - lib/apiconfig
   - lib/apis/v3
@@ -49,7 +49,7 @@ import:
   subpackages:
   - core/v1
 - package: k8s.io/client-go
-  version: v8.0.0
+  version: v12.0.0
   subpackages:
   - kubernetes
   - tools/clientcmd

--- a/pkg/cni/token_watch.go
+++ b/pkg/cni/token_watch.go
@@ -1,0 +1,108 @@
+package cni
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/fsnotify/fsnotify.v1"
+	"k8s.io/client-go/rest"
+)
+
+var serviceaccountDirectory string = "/var/run/secrets/kubernetes.io/serviceaccount/"
+var kubeconfigPath string = "/host/etc/cni/net.d/calico-kubeconfig"
+
+func Run() {
+	// Log to stdout.  this prevents our logs from being interpreted as errors by, for example,
+	// fluentd's default configuration.
+	logrus.SetOutput(os.Stdout)
+
+	// Create a watcher for file changes.
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		err := watcher.Close()
+		if err != nil {
+			logrus.WithError(err).Error("Failed to close file watcher")
+		}
+	}()
+
+	// Watch for changes to the serviceaccount directory. Rety if necessary.
+	for {
+		if err := watcher.Add(serviceaccountDirectory); err != nil {
+			// Error watching the file - retry
+			logrus.WithError(err).Error("Failed to watch Kubernetes serviceaccount files.")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		// Successfully watched the file. Break from the retry loop.
+		logrus.WithField("directory", serviceaccountDirectory).Info("Watching contents for changes.")
+		break
+	}
+
+	// Handle events from the watcher.
+	for {
+		// To prevent tight looping, add a sleep here.
+		time.Sleep(1 * time.Second)
+
+		select {
+		case event := <-watcher.Events:
+			// We've received a notification that the Kubernetes secrets files have changed.
+			// Update the kubeconfig file on disk to match.
+			logrus.WithField("event", event).Info("Notified of change to serviceaccount files.")
+			cfg, err := rest.InClusterConfig()
+			if err != nil {
+				logrus.WithError(err).Error("Error generating kube config.")
+				continue
+			}
+			err = rest.LoadTLSFiles(cfg)
+			if err != nil {
+				logrus.WithError(err).Error("Error loading TLS files.")
+				continue
+			}
+			writeKubeconfig(cfg)
+
+		case err := <-watcher.Errors:
+			// We've received an error - log it out but don't exit.
+			logrus.WithError(err).Error("Error watching serviceaccount files.")
+		}
+	}
+}
+
+// writeKubeconfig writes an updated kubeconfig file to disk that the CNI plugin can use to access the Kubernetes API.
+func writeKubeconfig(cfg *rest.Config) {
+	template := `# Kubeconfig file for Calico CNI plugin. Installed by calico/node.
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: %s
+    certificate-authority-data: "%s"
+users:
+- name: calico
+  user:
+    token: %s
+contexts:
+- name: calico-context
+  context:
+    cluster: local
+    user: calico
+current-context: calico-context`
+
+	// Replace the placeholders.
+	data := fmt.Sprintf(template, cfg.Host, string(base64.StdEncoding.EncodeToString(cfg.CAData)), cfg.BearerToken)
+
+	// Write the filled out config to disk.
+	if err := ioutil.WriteFile(kubeconfigPath, []byte(data), 0600); err != nil {
+		logrus.WithError(err).Error("Failed to write CNI plugin kubeconfig file")
+		return
+	}
+	logrus.WithField("path", kubeconfigPath).Info("Wrote updated CNI kubeconfig file.")
+}


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds support for token projection. Includes https://github.com/projectcalico/typha/pull/321

- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update client-go to support BoundServiceAccountTokenVolumes 
```

Also includes a cherry pick of https://github.com/projectcalico/node/pull/344 which is also required for token projection. 

```release-note
calico/node now updates CNI kubeconfig when credentials change
```