### PR TITLE
use arm64 image for etcd when Dockerfile is arm64

### DIFF
--- a/calico_test/Dockerfile.arm64.calico_test
+++ b/calico_test/Dockerfile.arm64.calico_test
@@ -46,9 +46,9 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 
 # Install etcdctl
-RUN wget https://github.com/coreos/etcd/releases/download/v2.3.3/etcd-v2.3.3-linux-amd64.tar.gz && \
-    tar -xzf etcd-v2.3.3-linux-amd64.tar.gz && \
-    cd etcd-v2.3.3-linux-amd64 && \
+RUN wget https://github.com/coreos/etcd/releases/download/v3.2.4/etcd-v3.2.4-linux-arm64.tar.gz && \
+    tar -xzf etcd-v3.2.4-linux-arm64.tar.gz && \
+    cd etcd-v3.2.4-linux-arm64 && \
     ln -s etcdctl /usr/local/bin/
 
 # The container is used by mounting the code-under-test to /code


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
use arm64 image for etcd when Dockerfile is arm64
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
