### PR TITLE
Pin ubi-minimal image to 8.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -93,7 +93,9 @@ RUN wget -P /tmp http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz && \
     cd /tmp/admin/runit-${RUNIT_VER}/ && \
     package/install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+# Pin image to ubi:8.0 for now. ubi:8.1 addresses low/moderate CVEs and includes updates to preinstalled packages.
+# However, CentOS packages for those CVE updates lag behind upstream so we will need to wait until those packages are available
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
 ARG ARCH
 ARG GIT_VERSION
 ARG IPTABLES_VER
@@ -145,6 +147,10 @@ RUN rm /etc/yum.repos.d/ubi.repo && \
     # Set alternatives
     alternatives --install /usr/sbin/iptables iptables /usr/sbin/iptables-legacy 1 && \
     alternatives --install /usr/sbin/ip6tables ip6tables /usr/sbin/ip6tables-legacy 1
+
+# Add mitigation for https://access.redhat.com/security/cve/CVE-2019-15718
+# This can be removed once we update to ubi:8.1
+RUN systemctl disable systemd-resolved
 
 # Copy our bird binaries in
 COPY --from=bird /bird* /bin/


### PR DESCRIPTION
This PR pins the ubi-minimal image to the `8.0` family. The `latest` tag points to the `8.1-279` image which we can't update to right now.

We can't update to 8.1 because it includes multiple upstream (RH) package updates that are not yet available in CentOS. Installing CentOS 8 packages onto ubi:8.1 simply won't work due to dependency version mismatches. For now, we will pin to `8.0` which contains low and medium CVEs. Note that this does not impact certification which looks for Severe and Critical vulnerabilities.

For more details about the CVEs in 8.0, see https://access.redhat.com/containers/?architecture=#/registry.access.redhat.com/ubi8/ubi/images/8.0-208

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
