### PR TITLE
[PATCH] Update Release v3.9

### DIFF
--- a/cmd/calico-node/main.go
+++ b/cmd/calico-node/main.go
@@ -45,6 +45,7 @@ var monitorToken = flagSet.Bool("monitor-token", false, "Watch for Kubernetes to
 
 // Options for liveness checks.
 var felixLive = flagSet.Bool("felix-live", false, "Run felix liveness checks")
+var birdLive = flagSet.Bool("bird-live", false, "Run bird liveness checks")
 
 // Options for readiness checks.
 var birdReady = flagSet.Bool("bird-ready", false, "Run BIRD readiness checks")
@@ -89,8 +90,8 @@ func main() {
 	}
 
 	// Check for liveness / readiness flags. Will only run checks specified by flags.
-	if *felixLive || *birdReady || *bird6Ready || *felixReady {
-		health.Run(*birdReady, *bird6Ready, *felixReady, *felixLive, *thresholdTime)
+	if *felixLive || *birdReady || *bird6Ready || *felixReady || *birdLive {
+		health.Run(*birdReady, *bird6Ready, *felixReady, *felixLive, *birdLive, *thresholdTime)
 		os.Exit(0)
 	}
 

--- a/cmd/calico-node/main.go
+++ b/cmd/calico-node/main.go
@@ -46,6 +46,7 @@ var monitorToken = flagSet.Bool("monitor-token", false, "Watch for Kubernetes to
 // Options for liveness checks.
 var felixLive = flagSet.Bool("felix-live", false, "Run felix liveness checks")
 var birdLive = flagSet.Bool("bird-live", false, "Run bird liveness checks")
+var bird6Live = flagSet.Bool("bird6-live", false, "Run bird6 liveness checks")
 
 // Options for readiness checks.
 var birdReady = flagSet.Bool("bird-ready", false, "Run BIRD readiness checks")
@@ -90,8 +91,8 @@ func main() {
 	}
 
 	// Check for liveness / readiness flags. Will only run checks specified by flags.
-	if *felixLive || *birdReady || *bird6Ready || *felixReady || *birdLive {
-		health.Run(*birdReady, *bird6Ready, *felixReady, *felixLive, *birdLive, *thresholdTime)
+	if *felixLive || *birdReady || *bird6Ready || *felixReady || *birdLive || *bird6Live {
+		health.Run(*birdReady, *bird6Ready, *felixReady, *felixLive, *birdLive, *bird6Live, *thresholdTime)
 		os.Exit(0)
 	}
 

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -47,26 +47,34 @@ func init() {
 	felixLivenessEp = "http://localhost:" + felixPort + "/liveness"
 }
 
-func Run(bird, bird6, felixReady, felixLive bool, birdLive bool, thresholdTime time.Duration) {
+func Run(bird, bird6, felixReady, felixLive, birdLive, bird6Live bool, thresholdTime time.Duration) {
+	livenessChecks := felixLive || birdLive  || bird6Live
+	readinessChecks := bird || felixReady || bird6
+
+	if !livenessChecks && !readinessChecks {
+		fmt.Printf("calico/node check error: must specify at least one of -bird-live, -bird6-live, -felix-live, -bird, -bird6, or -felix")
+		os.Exit(1)
+	}
+
 	if felixLive {
 		if err := checkFelixHealth(felixLivenessEp, "liveness"); err != nil {
 			fmt.Printf("calico/node is not ready: Felix is not live: %+v", err)
 			os.Exit(1)
 		}
-		os.Exit(0)
 	}
 
 	if birdLive {
-		if err := checkBIRDLive(); err != nil {
-			fmt.Printf("calico/node is not ready: Bird/ConfD is not live: %+v", err)
+		if err := checkServiceIsLive([]string{"confd", "bird"}); err != nil {
+			fmt.Printf("calico/node is not ready: bird/confd is not live: %+v", err)
 			os.Exit(1)
 		}
-		os.Exit(0)
 	}
 
-	if !bird && !felixReady && !bird6 {
-		fmt.Printf("calico/node readiness check error: must specify at least one of -bird, -bird6, or -felix")
-		os.Exit(1)
+	if bird6Live {
+		if err := checkServiceIsLive([]string{"confd", "bird6"}); err != nil {
+			fmt.Printf("calico/node is not ready: bird6/confd is not live: %+v", err)
+			os.Exit(1)
+		}
 	}
 
 	if felixReady {
@@ -91,35 +99,26 @@ func Run(bird, bird6, felixReady, felixLive bool, birdLive bool, thresholdTime t
 	}
 }
 
-func checkBIRDLive() error {
-	error := checkService("confd")
-	if error != nil {
-		return error
-	}
-
-	error = checkService("bird")
-	if error != nil {
-		return error
-	}
-
-	error = checkService("bird6")
-	if error != nil {
-		return error
+func checkServiceIsLive(services []string) error {
+	for _, service := range services {
+		err := checkService(service)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
 func checkService(serviceName string) error {
-	var svCheck = fmt.Sprintf("sv status /etc/service/enabled/%s", serviceName)
-	out, err := exec.Command(svCheck).Output()
+	out, err := exec.Command("sv", "status", fmt.Sprintf("/etc/service/enabled/%s", serviceName)).Output()
 	if err != nil {
 		return err
 	}
 
 	var cmdOutput = string(out)
 	if !strings.HasPrefix(cmdOutput, "run") {
-		return fmt.Errorf(fmt.Sprintf("Service %s is not running. Output << %s >>", serviceName, cmdOutput))
+		return fmt.Errorf(fmt.Sprintf("Service %s is not running. Output << %s >>", serviceName, strings.Trim(cmdOutput, "\n")))
 	}
 
 	return nil

--- a/tests/st/bgp/test_bgp.py
+++ b/tests/st/bgp/test_bgp.py
@@ -79,6 +79,58 @@ class TestReadiness(TestBase):
             retry_until_success(host1.assert_is_live, retries=30)
             retry_until_success(host2.assert_is_live, retries=30)
 
+    def test_liveness_bird_down(self):
+        """
+        Simulate bird service to be down.
+        """
+        with DockerHost('host1',
+                        additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS) as host1:
+            retry_until_success(host1.assert_is_ready, retries=30)
+            host1.execute("docker exec -it calico-node sv stop /etc/service/enabled/bird")
+
+            # Check that the readiness script is reporting 'not ready'
+            self.assertRaisesRegexp(CalledProcessError, "calico/node is not ready: bird/confd is not live: Service bird is not running.",
+                                host1.execute, "docker exec calico-node /bin/calico-node -bird-live")
+
+    def test_liveness_bird_confd_down(self):
+        """
+        Simulate confd service to be down for bird
+        """
+        with DockerHost('host1',
+                        additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS) as host1:
+            retry_until_success(host1.assert_is_ready, retries=30)
+            host1.execute("docker exec -it calico-node sv stop /etc/service/enabled/confd")
+
+            # Check that the readiness script is reporting 'not ready'
+            self.assertRaisesRegexp(CalledProcessError, "calico/node is not ready: bird/confd is not live: Service confd is not running.",
+                                    host1.execute, "docker exec calico-node /bin/calico-node -bird-live")
+
+    def test_liveness_bird6_down(self):
+        """
+        Simulate bird6 service to be down.
+        """
+        with DockerHost('host1',
+                        additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS) as host1:
+            retry_until_success(host1.assert_is_ready, retries=30)
+            host1.execute("docker exec -it calico-node sv stop /etc/service/enabled/bird6")
+
+            # Check that the readiness script is reporting 'not ready'
+            self.assertRaisesRegexp(CalledProcessError, "calico/node is not ready: bird6/confd is not live: Service bird6 is not running.",
+                                    host1.execute, "docker exec calico-node /bin/calico-node -bird6-live")
+
+    def test_liveness_bird6_confd_down(self):
+        """
+        Simulate confd service to be down for bird6
+        """
+        with DockerHost('host1',
+                    additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS) as host1:
+            retry_until_success(host1.assert_is_ready, retries=30)
+            host1.execute("docker exec -it calico-node sv stop /etc/service/enabled/confd")
+
+            # Check that the readiness script is reporting 'not ready'
+            self.assertRaisesRegexp(CalledProcessError, "calico/node is not ready: bird/confd is not live: Service confd is not running.",
+                                host1.execute, "docker exec calico-node /bin/calico-node -bird-live")
+
     def test_not_ready_with_broken_felix(self):
         """
         Simulate a broken felix by turning off Felix's health endpoint.

--- a/tests/st/utils/docker_host.py
+++ b/tests/st/utils/docker_host.py
@@ -188,10 +188,14 @@ class DockerHost(object):
 
         self.execute(cmd)
 
-    def assert_is_live(self, felix=True):
+    def assert_is_live(self, felix=True, bird=True, bird6=True):
         cmd = "docker exec calico-node /bin/calico-node"
         if felix:
             cmd += " -felix-live"
+        if bird:
+            cmd += " -bird-live"
+        if bird6:
+            cmd += " -bird6-live"
 
         self.execute(cmd)
 


### PR DESCRIPTION
## Description
These checks will be enabled when using option -bird-live or -bird6-live for the liveness probe. The default will be false.

projectcalico/calico#2889

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
```
Adding -bird-live/-bird6-live option to check for bird, bird6 and conf as part of the liveness probe.
```
