### PR TITLE
Revert "Use new BIRD without orig_gw hack"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ PUSH_IMAGES?=$(BUILD_IMAGE) quay.io/calico/node
 RELEASE_IMAGES?=gcr.io/projectcalico-org/node eu.gcr.io/projectcalico-org/node asia.gcr.io/projectcalico-org/node us.gcr.io/projectcalico-org/node
 
 # Versions and location of dependencies used in the build.
-BIRD_VERSION=v0.3.3-147-g1c33c691
+BIRD_VERSION=v0.3.3-145-g049d13dc
 BIRD_IMAGE ?= calico/bird:$(BIRD_VERSION)-$(ARCH)
 
 # Versions and locations of dependencies used in tests.


### PR DESCRIPTION
This reverts commit 491dc7c78fdb99eaaa862ffc5b8d413117b6590a.

Just reverting this until we've created a 3.11 release branch...