### PR TITLE
fail fast & retry setting NetworkUnavailable to false

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -1129,6 +1129,9 @@ func setNodeNetworkUnavailableFalse(config rest.Config, nodeName string) error {
 			_, err = clientset.CoreV1().Nodes().PatchStatus(nodeName, patch)
 			if err != nil {
 				log.WithError(err).Warnf("Failed to set NetworkUnavailable to False; will retry")
+			} else {
+				// Success!
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
If kube-proxy isn't working when we start, we'll currently wait ~30 seconds to timeout. This changes to a 2 second timeout, retried until a total of 30 seconds.  This should address the case where kube-proxy is ready a few seconds after Calico starts.

## Todos
- [ ] Tests
- [x] Documentation not needed
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fail fast & retry setting NetworkUnavailable to false (issue #307 )
```
