### PR TITLE
Pin calicoctl to v3.11 instead of master (for release-v3.11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ BIRD_VERSION=v0.3.3-147-g1c33c691
 BIRD_IMAGE ?= calico/bird:$(BIRD_VERSION)-$(ARCH)
 
 # Versions and locations of dependencies used in tests.
-CALICOCTL_VER?=master
+CALICOCTL_VER?=release-v3.11
 CNI_VER?=master
 TEST_CONTAINER_NAME_VER?=latest
 CTL_CONTAINER_NAME?=calico/ctl:$(CALICOCTL_VER)-$(ARCH)


### PR DESCRIPTION
- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```