### PR TITLE
Restructure BGP tests to avoid double setup for RR test

### DIFF
--- a/tests/k8st/tests/test_bgp_advert.py
+++ b/tests/k8st/tests/test_bgp_advert.py
@@ -92,10 +92,10 @@ protocol bgp Mesh_with_node_2 from bgp_template {
 }
 """
 
-class TestBGPAdvert(TestBase):
+class _TestBGPAdvert(TestBase):
 
     def setUp(self):
-        super(TestBGPAdvert, self).setUp()
+        super(_TestBGPAdvert, self).setUp()
 
         # Create bgp test namespace
         self.ns = "bgp-test"
@@ -104,7 +104,7 @@ class TestBGPAdvert(TestBase):
         self.nodes, self.ips, _ = node_info()
         self.external_node_ip = start_external_node_with_bgp(
             "kube-node-extra",
-            bird_peer_config=bird_conf % (self.ips[0], self.ips[1], self.ips[2], self.ips[3])
+            bird_peer_config=self.get_bird_conf(),
         )
 
         # Enable debug logging
@@ -118,47 +118,12 @@ class TestBGPAdvert(TestBase):
 apiVersion: projectcalico.org/v3
 kind: BGPPeer
 metadata:
-  name: node-extra.peer
-spec:
-  peerIP: %s
-  asNumber: 64512
+  name: node-extra.peer%s
 EOF
-""" % self.external_node_ip)
-
-    def setUpRR(self):
-        super(TestBGPAdvert, self).setUp()
-
-        # Create bgp test namespace
-        self.ns = "bgp-test"
-        self.create_namespace(self.ns)
-
-        self.nodes, self.ips, _ = node_info()
-        self.external_node_ip = start_external_node_with_bgp(
-            "kube-node-extra",
-            bird_peer_config=bird_conf_rr % self.ips[2]
-        )
-
-        # Enable debug logging
-        self.update_ds_env("calico-node",
-                           "kube-system",
-                           "BGP_LOGSEVERITYSCREEN",
-                           "debug")
-
-        # Establish BGPPeer from cluster nodes to node-extra using calicoctl
-        calicoctl("""apply -f - << EOF
-apiVersion: projectcalico.org/v3
-kind: BGPPeer
-metadata:
-  name: node-extra.peer
-spec:
-  node: %s
-  peerIP: %s
-  asNumber: 64512
-EOF
-""" % (self.nodes[2], self.external_node_ip))
+""" % self.get_extra_peer_spec())
 
     def tearDown(self):
-        super(TestBGPAdvert, self).tearDown()
+        super(_TestBGPAdvert, self).tearDown()
         self.delete_and_confirm(self.ns, "ns")
         try:
             # Delete the extra node.
@@ -168,7 +133,7 @@ EOF
 
         # Delete BGPPeers.
         calicoctl("delete bgppeer node-extra.peer", allow_fail=True)
-        calicoctl("delete bgppeer kube-node-1", allow_fail=True)
+        calicoctl("delete bgppeer peer-with-rr", allow_fail=True)
 
         # Restore node-to-node mesh.
         calicoctl("""apply -f - << EOF
@@ -211,109 +176,31 @@ EOF
         patchStr = "{\"spec\": {\"externalIPs\": [%s]}}" % (ipsStr)
         return kubectl("patch svc %s -n %s --patch '%s'" % (svc, ns, patchStr)).strip()
 
-    def test_rr(self):
-        self.tearDown()
-        self.setUpRR()
 
-        # Create ExternalTrafficPolicy Local service with one endpoint on node-1
-        kubectl("""apply -f - << EOF
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-rr
-  namespace: bgp-test
-  labels:
-    app: nginx
+class TestBGPAdvert(_TestBGPAdvert):
+
+    # In the tests of this class we have a full BGP mesh between the
+    # cluster nodes (kube-control-plane, kube-node-1 and kube-node-2)
+    # and the external node (kube-node-extra):
+    #
+    # - The full mesh between the cluster nodes is configured by
+    #   nodeToNodeMeshEnabled: true.
+    #
+    # - The peerings from each cluster node to the external node are
+    #   configured by self.get_extra_peer_spec().
+    #
+    # - The peerings from the external node to each cluster node are
+    #   configured by self.get_bird_conf().
+
+    def get_bird_conf(self):
+        return bird_conf % (self.ips[0], self.ips[1], self.ips[2], self.ips[3])
+
+    def get_extra_peer_spec(self):
+        return """
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: nginx
-      run: nginx-rr
-  template:
-    metadata:
-      labels:
-        app: nginx
-        run: nginx-rr
-    spec:
-      containers:
-      - name: nginx-rr
-        image: nginx:1.7.9
-        ports:
-        - containerPort: 80
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-        kubernetes.io/hostname: %s
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: nginx-rr
-  namespace: bgp-test
-  labels:
-    app: nginx
-    run: nginx-rr
-spec:
-  externalIPs:
-  - 175.200.1.1
-  ports:
-  - port: 80
-    targetPort: 80
-  selector:
-    app: nginx
-    run: nginx-rr
-  type: NodePort
-  externalTrafficPolicy: Local
-EOF
-""" % self.nodes[1])
-
-        calicoctl("get nodes -o yaml")
-        calicoctl("get bgppeers -o yaml")
-        calicoctl("get bgpconfigs -o yaml")
-
-        # Update the node-2 to behave as a route-reflector
-        json_str = calicoctl("get node %s -o json" % self.nodes[2])
-        node_dict = json.loads(json_str)
-        node_dict['metadata']['labels']['i-am-a-route-reflector'] = 'true'
-        node_dict['spec']['bgp']['routeReflectorClusterID'] = '224.0.0.1'
-        calicoctl("""apply -f - << EOF
-%s
-EOF
-""" % json.dumps(node_dict))
-
-        # Disable node-to-node mesh and add cluster and external IPs CIDRs to advertise.
-        # Configure bgp peering between node-1 and RR and also between external node and RR.
-        calicoctl("""apply -f - << EOF
-apiVersion: projectcalico.org/v3
-kind: BGPConfiguration
-metadata:
-  name: default
-spec:
-  nodeToNodeMeshEnabled: false
-  asNumber: 64512
-  serviceClusterIPs:
-  - cidr: 10.96.0.0/12
-  serviceExternalIPs:
-  - cidr: 175.200.0.0/16
-EOF
-""")
-
-        calicoctl("""apply -f - << EOF
-apiVersion: projectcalico.org/v3
-kind: BGPPeer
-metadata: {name: kube-node-1}
-spec:
-  node: %s
   peerIP: %s
   asNumber: 64512
-EOF
-""" % (self.nodes[1], self.ips[2]))
-        svc_json = kubectl("get svc nginx-rr -n bgp-test -o json")
-        svc_dict = json.loads(svc_json)
-        cluster_ip = svc_dict['spec']['clusterIP']
-        external_ip = svc_dict['spec']['externalIPs'][0]
-        retry_until_success(lambda: self.assertIn(cluster_ip, self.get_routes()))
-        retry_until_success(lambda: self.assertIn(external_ip, self.get_routes()))
+""" % self.external_node_ip
 
     def test_cluster_ip_advertisement(self):
         """
@@ -547,9 +434,11 @@ EOF
             # Assert they are all advertised to the other node. This should happen
             # quickly enough that by the time we have queried all services from
             # the k8s API, they should be programmed on the remote node.
-            routes = self.get_routes()
-            for cip in cluster_ips:
-                self.assertIn(cip, routes)
+            def check_routes_advertised():
+                routes = self.get_routes()
+                for cip in cluster_ips:
+                    self.assertIn(cip, routes)
+            retry_until_success(check_routes_advertised, retries=3, wait_time=5)
 
             # Scale to 0 replicas, assert all routes are removed.
             self.scale_deployment(local_svc, self.ns, 0)
@@ -559,3 +448,133 @@ EOF
                 for cip in cluster_ips:
                     self.assertNotIn(cip, routes)
             retry_until_success(check_routes_gone, retries=10, wait_time=5)
+
+
+class TestBGPAdvertRR(_TestBGPAdvert):
+
+    # In the tests of this class, kube-node-2 acts as an RR, and all
+    # the other nodes peer with it.  Here are the peerings that we
+    # need for that:
+    #
+    #                                      RR
+    # kube-master     kube-node-1     kube-node-2    kube-node-extra
+    #  10.192.0.2      10.192.0.3      10.192.0.4      10.192.0.5
+    #        |                |         | |    |         |
+    #        |                +---------+ |    +---------+
+    #        +----------------------------+   Peering -> is configured
+    #           These peerings are            by get_extra_peer_spec().
+    #           configured by BGPPeer         Peering <- is configured
+    #           peer-with-rr                  in get_bird_conf().
+
+    def get_bird_conf(self):
+        return bird_conf_rr % self.ips[2]
+
+    def get_extra_peer_spec(self):
+        return """
+spec:
+  node: %s
+  peerIP: %s
+  asNumber: 64512
+""" % (self.nodes[2], self.external_node_ip)
+
+    def test_rr(self):
+        # Create ExternalTrafficPolicy Local service with one endpoint on node-1
+        kubectl("""apply -f - << EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-rr
+  namespace: bgp-test
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+      run: nginx-rr
+  template:
+    metadata:
+      labels:
+        app: nginx
+        run: nginx-rr
+    spec:
+      containers:
+      - name: nginx-rr
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        kubernetes.io/hostname: %s
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-rr
+  namespace: bgp-test
+  labels:
+    app: nginx
+    run: nginx-rr
+spec:
+  externalIPs:
+  - 175.200.1.1
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: nginx
+    run: nginx-rr
+  type: NodePort
+  externalTrafficPolicy: Local
+EOF
+""" % self.nodes[1])
+
+        calicoctl("get nodes -o yaml")
+        calicoctl("get bgppeers -o yaml")
+        calicoctl("get bgpconfigs -o yaml")
+
+        # Update the node-2 to behave as a route-reflector
+        json_str = calicoctl("get node %s -o json" % self.nodes[2])
+        node_dict = json.loads(json_str)
+        node_dict['metadata']['labels']['i-am-a-route-reflector'] = 'true'
+        node_dict['spec']['bgp']['routeReflectorClusterID'] = '224.0.0.1'
+        calicoctl("""apply -f - << EOF
+%s
+EOF
+""" % json.dumps(node_dict))
+
+        # Disable node-to-node mesh, add cluster and external IP CIDRs to
+        # advertise, and configure BGP peering between the cluster nodes and the
+        # RR.  (The BGP peering from the external node to the RR is included in
+        # bird_conf_rr above.)
+        calicoctl("""apply -f - << EOF
+apiVersion: projectcalico.org/v3
+kind: BGPConfiguration
+metadata:
+  name: default
+spec:
+  nodeToNodeMeshEnabled: false
+  asNumber: 64512
+  serviceClusterIPs:
+  - cidr: 10.96.0.0/12
+  serviceExternalIPs:
+  - cidr: 175.200.0.0/16
+EOF
+""")
+
+        calicoctl("""apply -f - << EOF
+apiVersion: projectcalico.org/v3
+kind: BGPPeer
+metadata: {name: peer-with-rr}
+spec:
+  peerIP: %s
+  asNumber: 64512
+EOF
+""" % self.ips[2])
+        svc_json = kubectl("get svc nginx-rr -n bgp-test -o json")
+        svc_dict = json.loads(svc_json)
+        cluster_ip = svc_dict['spec']['clusterIP']
+        external_ip = svc_dict['spec']['externalIPs'][0]
+        retry_until_success(lambda: self.assertIn(cluster_ip, self.get_routes()))
+        retry_until_success(lambda: self.assertIn(external_ip, self.get_routes()))


### PR DESCRIPTION
This is a similar restructuring as I did a while back in node-private
as part of https://github.com/tigera/node-private/pull/112.
Specifically it avoids the RR test doing:

  - setup (for a non-RR test)
  - immediately tear that down again
  - setup for an RR test

which IIUC can lead to a rare flake.
