### PR TITLE
add protocols section in nsswitch.conf

### DIFF
--- a/filesystem/etc/nsswitch.conf
+++ b/filesystem/etc/nsswitch.conf
@@ -1,1 +1,2 @@
 hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4
+protocols: files


### PR DESCRIPTION
## Description

Type of fix: bug fix

Problem: Running calico in a NIS enabled environment, with no protocols info, crashes calico-node pod.

Root cause: ipsets command tries to resolve the protocol by first looking up nis, followed by files. In an environment where NIS is enabled but the server doesn't respond with the protocol information, the files (/etc/protocols) information is not used. Hence, the crash.

Fix: Specify protocols section in nsswitch.conf

Issue(s): https://github.com/rancher/rancher/issues/24543


```release-note
None required
```
