### PR TITLE
Improve the name that Semaphore v2 displays

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,10 +5,10 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 blocks:
-  - name: Run k8s-tests
+  - name: 'Testing'
     task:
       jobs:
-      - name: Download code and run tests
+      - name: 'K8ST (make k8s-test)'
         commands:
           # Checkout the code and run the Kubernetes tests.
           - checkout


### PR DESCRIPTION
Doing this to be consistent with a similar change in node-private,
where we will have separate headings for K8ST and dual ToR.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
