### PR TITLE
Autoselect default IP pool if overlapping with host IPs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/kelseyhightower/confd v0.0.0-00010101000000-000000000000
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
+	github.com/pkg/errors v0.8.1
 	github.com/projectcalico/felix v0.0.0-20200302175626-ffd3291c6c5a
 	github.com/projectcalico/libcalico-go v1.7.2-0.20200225165413-26809aa675f6
 	github.com/sirupsen/logrus v1.4.2
+	github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7
 
 	k8s.io/api v0.0.0

--- a/pkg/startup/autodetection/ipv4/poolselector.go
+++ b/pkg/startup/autodetection/ipv4/poolselector.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ipv4
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	FALLBACK_IPPOOL_TEMPLATE = "172.%d.0.0/16"
+	FALLBACK_IPPOOL_MIN      = 16
+	FALLBACK_IPPOOL_MAX      = 31
+)
+
+var hostIPAddressRetriever func(netlink.Link, int) ([]netlink.Addr, error) = netlink.AddrList
+
+// GetDefaultIPv4Pool detects host interfaces and selects default IP pool without overlapping
+func GetDefaultIPv4Pool(preferedPool *net.IPNet) (*net.IPNet, error) {
+	log.Debug("Auto-detecting IPv4 interfaces to select default pool")
+
+	hostAddrs, err := retrieveIPAddresses()
+	if err != nil {
+		log.Errorf("Unable to retrieve host network interfaces: '%s'", err.Error())
+		return nil, err
+	}
+
+	return findAvailableCIDR(preferedPool, hostAddrs), nil
+}
+
+func retrieveIPAddresses() ([]net.IPNet, error) {
+	linkAddresses, err := hostIPAddressRetriever(nil, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to list addresses")
+	}
+
+	resp := make([]net.IPNet, len(linkAddresses))
+	for _, addr := range linkAddresses {
+		resp = append(resp, *addr.IPNet)
+	}
+
+	return resp, nil
+}
+
+func findAvailableCIDR(preferredPool *net.IPNet, hostAddrs []net.IPNet) *net.IPNet {
+	if !doesPoolOverlap(preferredPool, hostAddrs) {
+		return preferredPool
+	}
+
+	for i := FALLBACK_IPPOOL_MIN; i <= FALLBACK_IPPOOL_MAX; i++ {
+		_, poolToTry, _ := net.ParseCIDR(fmt.Sprintf(FALLBACK_IPPOOL_TEMPLATE, i))
+		if !doesPoolOverlap(poolToTry, hostAddrs) {
+			return poolToTry
+		}
+	}
+
+	// We couldn't find a pool. For compatibility reasons, return the preferred pool to match existing behavior.
+	return preferredPool
+}
+
+func doesPoolOverlap(preferredPool *net.IPNet, hostAddrs []net.IPNet) bool {
+	for _, addr := range hostAddrs {
+		if preferredPool.Contains(addr.IP) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/startup/autodetection/ipv4/poolselector_test.go
+++ b/pkg/startup/autodetection/ipv4/poolselector_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ipv4
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/vishvananda/netlink"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommands(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../../report/autodetection_ipv4_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "IPv4 pool selector Suite", []Reporter{junitReporter})
+}
+
+var _ = Describe("IPv4 pool selector tests", func() {
+	Describe("Pool selector tests", func() {
+		It("select default because not overlapping", func() {
+			actualNet := parseCIDR("192.168.0.0/16")
+			hostAddresses := []net.IPNet{parseCIDR("192.169.64.2/24")}
+
+			selected := findAvailableCIDR(&actualNet, hostAddresses)
+
+			Expect(*selected).To(Equal(parseCIDR("192.168.0.0/16")))
+		})
+
+		It("select first from range because it is overlapping", func() {
+			actualNet := parseCIDR("192.168.0.0/16")
+			hostAddresses := []net.IPNet{parseCIDR("192.168.64.2/24")}
+
+			selected := findAvailableCIDR(&actualNet, hostAddresses)
+
+			Expect(*selected).To(Equal(parseCIDR("172.16.0.0/16")))
+		})
+
+		It("select second from range because it is overlapping", func() {
+			actualNet := parseCIDR("192.168.0.0/16")
+			hostAddresses := []net.IPNet{parseCIDR("192.168.64.2/24"), parseCIDR("172.16.0.1/16")}
+
+			selected := findAvailableCIDR(&actualNet, hostAddresses)
+
+			Expect(*selected).To(Equal(parseCIDR("172.17.0.0/16")))
+		})
+
+		It("should fail because all are overlapping", func() {
+			actualNet := parseCIDR("192.168.0.0/16")
+			hostAddresses := []net.IPNet{parseCIDR("192.168.64.2/24")}
+			for i := FALLBACK_IPPOOL_MIN; i <= FALLBACK_IPPOOL_MAX; i++ {
+				hostAddresses = append(hostAddresses, parseCIDR(fmt.Sprintf(FALLBACK_IPPOOL_TEMPLATE, i)))
+			}
+
+			selected := findAvailableCIDR(&actualNet, hostAddresses)
+
+			Expect(*selected).To(Equal(actualNet))
+		})
+	})
+
+	Describe("Get default IPv4 pool tests", func() {
+		var originalRetriever func(netlink.Link, int) ([]netlink.Addr, error)
+
+		BeforeEach(func() {
+			originalRetriever = hostIPAddressRetriever
+		})
+
+		AfterEach(func() {
+			hostIPAddressRetriever = originalRetriever
+		})
+
+		It("unable to retrieve host addresses", func() {
+			hostIPAddressRetriever = func(netlink.Link, int) ([]netlink.Addr, error) {
+				return []netlink.Addr{}, errors.New("fatal error")
+			}
+			_, preferredPool, _ := net.ParseCIDR("192.168.0.0/16")
+
+			_, err := GetDefaultIPv4Pool(preferredPool)
+
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("select first from range because it is overlapping", func() {
+			hostIPAddressRetriever = func(netlink.Link, int) ([]netlink.Addr, error) {
+				net := parseCIDR("192.168.64.2/24")
+				return []netlink.Addr{netlink.Addr{IPNet: &net}}, nil
+			}
+			_, preferredPool, _ := net.ParseCIDR("192.168.0.0/16")
+
+			selected, _ := GetDefaultIPv4Pool(preferredPool)
+
+			Expect(*selected).To(Equal(parseCIDR("172.16.0.0/16")))
+		})
+	})
+})
+
+func parseCIDR(s string) net.IPNet {
+	_, n, _ := net.ParseCIDR(s)
+	return *n
+}

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -41,6 +41,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/upgrade/migrator/clients"
 	"github.com/projectcalico/node/pkg/calicoclient"
 	"github.com/projectcalico/node/pkg/startup/autodetection"
+	"github.com/projectcalico/node/pkg/startup/autodetection/ipv4"
 	log "github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -821,6 +822,13 @@ func configureIPPools(ctx context.Context, client client.Interface, kubeadmConfi
 	// Read IPV4 CIDR from env if set and parse then check it for errors
 	if ipv4Pool == "" {
 		ipv4Pool = DEFAULT_IPV4_POOL_CIDR
+
+		_, preferedNet, _ := net.ParseCIDR(DEFAULT_IPV4_POOL_CIDR)
+		if selectedPool, err := ipv4.GetDefaultIPv4Pool(preferedNet); err == nil {
+			ipv4Pool = selectedPool.String()
+		}
+
+		log.Infof("Selected default IP pool is '%s'", ipv4Pool)
 	}
 	_, ipv4Cidr, err := cnet.ParseCIDR(ipv4Pool)
 	if err != nil || ipv4Cidr.Version() != 4 {

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -74,6 +74,14 @@ func makeNode(ipv4 string, ipv6 string) *api.Node {
 	return n
 }
 
+var _ = Describe("Default IPv4 pool CIDR", func() {
+
+	It("default pool must be valid", func() {
+		_, _, err := net.ParseCIDR(DEFAULT_IPV4_POOL_CIDR)
+		Expect(err).To(BeNil())
+	})
+})
+
 var _ = Describe("Non-etcd related tests", func() {
 
 	Describe("Termination tests", func() {


### PR DESCRIPTION
## Description
Default IP pool can overlap with user's host network. This new feature introduced a logic to select different one on case of overlapping. On any case of error it fallbacks to the original default pool, so the change doesn't break current behavior. On case of overlapping calico node starts to find free IP range between `172.16.0.0/16` and `172.31.0.0/16`. This PR is related to https://github.com/projectcalico/calico/issues/1401. I have tested it manually and covered the change fully with automated test cases.

## Todos
- [ ] Tests
- [X] Documentation
- [x] Release note

## Release Note

```release-note
On case of overlapping between host network and default IP pool Calico node start to find a free IP range between `172.16.0.0/16` and `172.31.0.0/16`
```
