### PR TITLE
Release tunnel addresses by handle

### DIFF
--- a/pkg/allocateip/allocateip.go
+++ b/pkg/allocateip/allocateip.go
@@ -361,9 +361,30 @@ func removeHostTunnelAddr(ctx context.Context, c client.Interface, nodename stri
 			node.Spec.BGP = nil
 		}
 
-		// Release the IP.
-		if _, err := c.IPAM().ReleaseIPs(ctx, []net.IP{*ipAddr}); err != nil {
-			logCtx.WithError(err).WithField("IP", ipAddr.String()).Fatal("Error releasing address from IPAM")
+		// Release tunnel IP address(es) for the node.
+		handle, _ := generateHandleAndAttributes(nodename, vxlan)
+		if err := c.IPAM().ReleaseByHandle(ctx, handle); err != nil {
+			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
+				// Unknown error releasing the address.
+				logCtx.WithError(err).WithField("IP", ipAddr.String()).Fatal("Error releasing address by handle")
+			}
+
+			// There are no addresses with this handle. Check to see if the IP on the node
+			// belongs to us. If it has no handle and no attributes, then we can pretty confidently
+			// say that it belongs to us rather than a pod and should be cleaned up.
+			logCtx.WithField("handle", handle).Info("No IPs with handle, release exact IP")
+			attr, handle, err := c.IPAM().GetAssignmentAttributes(ctx, *ipAddr)
+			if err != nil {
+				if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
+					logCtx.WithError(err).Fatal("Failed to query attributes")
+				}
+				// No allocation exists, we don't have anything to do.
+			} else if len(attr) == 0 && handle == nil {
+				// The IP is ours. Release it by passing the exact IP.
+				if _, err := c.IPAM().ReleaseIPs(ctx, []net.IP{*ipAddr}); err != nil {
+					logCtx.WithError(err).WithField("IP", ipAddr.String()).Fatal("Error releasing address from IPAM")
+				}
+			}
 		}
 
 		// Update the node object.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This is the final PR in the trilogy for closing down IP address leaking
for tunnel addresses, and specifically covers a case where we were vulnerable to accidentally releasing an IP address that might not have been ours. 

Previous PRs in the series:
- #436 
- #430 

At this point:

- tunnel IPs will either be assigned using a handle, OR
- tunnel IPs will have been assigned without a handle and corrected to
use one, OR 
- tunnel IPs will have been assigned without a handle, and on upgrade to
the new code we determine we need to release the IP prior to correcting
it. In this case, it also will have no attributes.

Ideally we would only ever release by handle, but to cover a tiny edge case where we might not have corrected old allocations to use a handle yet, we still fallback to releasing using the exact IP address, but only if we can confirm with a lot of certainty that the IP is in fact an old address that still belongs to us (assigned prior to the use of handles and attributes).


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Release tunnel IP addresses more safely
```