### PR TITLE
Add GlobalNetworkPolicy short name

### DIFF
--- a/tests/k8st/infra/calico-kdd.yaml
+++ b/tests/k8st/infra/calico-kdd.yaml
@@ -213,6 +213,8 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+    shortNames:
+    - gnp
 
 ---
 


### PR DESCRIPTION
## Description
This PR introduces a short name for GlobalNetworkPolicy Custom Resource to keep CRD sync with Calico official.

## Related issues/PRs
fixes https://github.com/projectcalico/calico/issues/2651
related to: https://github.com/projectcalico/calico/pull/3436

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
```release-note
GlobalNetworkPolicy Custom Resource definition has a new alias `gnp` to make `kubectl` commands more simple.
```
