### PR TITLE
Fix bird health check return error message when BIRD service report "connect: resource temporarily unavailable"

### DIFF
--- a/pkg/health/bird/bird.go
+++ b/pkg/health/bird/bird.go
@@ -39,6 +39,10 @@ func GRInProgress(ipv string) (bool, error) {
 	// Try connecting to the BIRD socket in `/var/run/calico/` first to get the data
 	c, err := net.Dial("unix", fmt.Sprintf("/var/run/calico/bird%s.ctl", birdSuffix))
 	if err != nil {
+		// If that fails and BIRD socket file exists, return the error message
+		if !isNotExistError(err) {
+			return false, fmt.Errorf("Error querying BIRD: connect to BIRDv%s socket: %v", ipv, err)
+		}
 		// If that fails, try connecting to BIRD socket in `/var/run/bird` (which is the
 		// default socket location for BIRD install) for non-containerized installs
 		log.Debugln("Failed to connect to BIRD socket in /var/run/calico, trying /var/run/bird")
@@ -112,6 +116,10 @@ func GRInProgress(ipv string) (bool, error) {
 	return false, scanner.Err()
 }
 
+func isNotExistError(err error) bool {
+	return strings.HasSuffix(err.Error(), "no such file or directory")
+}
+
 // bgpPeer is a structure containing details about a BGP peer.
 type bgpPeer struct {
 	PeerIP   string
@@ -132,6 +140,10 @@ func GetPeers(ipv string) ([]bgpPeer, error) {
 	// Try connecting to the BIRD socket in `/var/run/calico/` first to get the data
 	c, err := net.Dial("unix", fmt.Sprintf("/var/run/calico/bird%s.ctl", birdSuffix))
 	if err != nil {
+		// If that fails and BIRD socket file exists, return the error message
+		if !isNotExistError(err) {
+			return nil, fmt.Errorf("Error querying BIRD: connect to BIRDv%s socket: %v", ipv, err)
+		}
 		// If that fails, try connecting to BIRD socket in `/var/run/bird` (which is the
 		// default socket location for BIRD install) for non-containerized installs
 		log.Debugln("Failed to connect to BIRD socket in /var/run/calico, trying /var/run/bird")


### PR DESCRIPTION
## Description
bug fix, add error type judge before retry connect to `/var/run/bird`
Closes:https://github.com/projectcalico/node/issues/463
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
When connecting to BIRD  check the BIRD socket file
```
