### PR TITLE
Remove auto-promotion of update-pins hook

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,9 +17,7 @@ global_job_config:
 promotions:
 - name: Auto-update and commit dependency pins
   pipeline_file: update-pins.yml
-  auto_promote:
-    # Auto-update pins only if the build passed and only for master.
-    when: "result = 'passed' and branch = 'master'"
+  # No auto-promotion, update-pins.yml gets run directly by the scheduler.
 - name: Push images
   pipeline_file: push-images.yml
   auto_promote:

--- a/.semaphore/update-pins.yml
+++ b/.semaphore/update-pins.yml
@@ -22,5 +22,4 @@ blocks:
     jobs:
     - name: "make commit-pin-updates"
       commands:
-      # To save cycles, only run if triggered manually or by the nightly build.
-      - if ! $SEMAPHORE_WORKFLOW_TRIGGERED_BY_HOOK; then make commit-pin-updates; fi
+      - make commit-pin-updates


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

* Allow the pin update promotion to be triggered manually by removing the guard.
* (Also, added a scheduled run of update-pins.yml each night in the semaphore v2 UI.)


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
