### PR TITLE
By default, exclude cni.* from auto detection

### DIFF
--- a/pkg/startup/startup_linux.go
+++ b/pkg/startup/startup_linux.go
@@ -12,7 +12,7 @@ import (
 var DEFAULT_INTERFACES_TO_EXCLUDE []string = []string{
 	"docker.*", "cbr.*", "dummy.*",
 	"virbr.*", "lxcbr.*", "veth.*", "lo",
-	"cali.*", "tunl.*", "flannel.*", "kube-ipvs.*",
+	"cali.*", "tunl.*", "flannel.*", "kube-ipvs.*", "cni.*",
 }
 
 const defaultNodenameFile = "/var/lib/calico/nodename"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Added cni.* to excluded interfaces to avoid troubles in k8s with cri-o as runtime.

Related issues:
[Calico-cri-o]Worker nodes calico-node-xxxxx CrashLoopbackOff due to already allocated IP - https://github.com/projectcalico/calico/issues/3616

```release-note
By default, exclude cni.* from node IP auto detection
```