### PR TITLE
Pr calico node more logs

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -368,7 +368,7 @@ func waitForConnection(ctx context.Context, c client.Interface) {
 		if err != nil {
 			switch err.(type) {
 			case cerrors.ErrorConnectionUnauthorized:
-				log.Warn("Connection to the datastore is unauthorized")
+				log.WithError(err).Warn("Connection to the datastore is unauthorized")
 				terminate()
 			case cerrors.ErrorDatastoreError:
 				log.WithError(err).Info("Hit error connecting to datastore - retry")


### PR DESCRIPTION
## Description

Improves debug logs of `calico-node -startup`. It's really hard to debug Kubernetes authorization errors without the detailed error message.

