### PR TITLE
Properly handle disabled autodetection

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -453,6 +453,9 @@ func configureIPsAndSubnets(node *api.Node) (bool, error) {
 			log.Warnf("Autodetection of IPv4 address failed, keeping existing value: %s", node.Spec.BGP.IPv4Address)
 			validateIP(node.Spec.BGP.IPv4Address)
 		}
+	} else if ipv4Env == "none" && node.Spec.BGP.IPv4Address != "" {
+		log.Warnf("Autodetection for IPv4 disabled, keeping existing value: %s", node.Spec.BGP.IPv4Address)
+		validateIP(node.Spec.BGP.IPv4Address)
 	} else if ipv4Env != "none" {
 		if ipv4Env != "" {
 			node.Spec.BGP.IPv4Address = parseIPEnvironment("IP", ipv4Env, 4)
@@ -478,6 +481,9 @@ func configureIPsAndSubnets(node *api.Node) (bool, error) {
 			log.Warnf("Autodetection of IPv6 address failed, keeping existing value: %s", node.Spec.BGP.IPv6Address)
 			validateIP(node.Spec.BGP.IPv6Address)
 		}
+	} else if ipv6Env == "none" && node.Spec.BGP.IPv6Address!="" {
+		log.Warnf("Autodetection for IPv6 disabled, keeping existing value: %s", node.Spec.BGP.IPv6Address)
+		validateIP(node.Spec.BGP.IPv6Address)	
 	} else if ipv6Env != "none" {
 		if ipv6Env != "" {
 			node.Spec.BGP.IPv6Address = parseIPEnvironment("IP6", ipv6Env, 6)
@@ -485,7 +491,7 @@ func configureIPsAndSubnets(node *api.Node) (bool, error) {
 		validateIP(node.Spec.BGP.IPv6Address)
 	}
 
-	if ipv4Env == "none" && (ipv6Env == "" || ipv6Env == "none") {
+	if ipv4Env == "none" && (ipv6Env == "" || ipv6Env == "none") && node.Spec.BGP.IPv4Address == "" && node.Spec.BGP.IPv6Address == "" {
 		log.Warn("No IP Addresses configured, and autodetection is not enabled")
 		terminate()
 	}

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -454,7 +454,7 @@ func configureIPsAndSubnets(node *api.Node) (bool, error) {
 			validateIP(node.Spec.BGP.IPv4Address)
 		}
 	} else if ipv4Env == "none" && node.Spec.BGP.IPv4Address != "" {
-		log.Warnf("Autodetection for IPv4 disabled, keeping existing value: %s", node.Spec.BGP.IPv4Address)
+		log.Infof("Autodetection for IPv4 disabled, keeping existing value: %s", node.Spec.BGP.IPv4Address)
 		validateIP(node.Spec.BGP.IPv4Address)
 	} else if ipv4Env != "none" {
 		if ipv4Env != "" {
@@ -482,7 +482,7 @@ func configureIPsAndSubnets(node *api.Node) (bool, error) {
 			validateIP(node.Spec.BGP.IPv6Address)
 		}
 	} else if ipv6Env == "none" && node.Spec.BGP.IPv6Address!="" {
-		log.Warnf("Autodetection for IPv6 disabled, keeping existing value: %s", node.Spec.BGP.IPv6Address)
+		log.Infof("Autodetection for IPv6 disabled, keeping existing value: %s", node.Spec.BGP.IPv6Address)
 		validateIP(node.Spec.BGP.IPv6Address)	
 	} else if ipv6Env != "none" {
 		if ipv6Env != "" {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
If IP or IP6 environment variable is set to "none" try to use existing address and not terminate. This fixes calico to work as specified in documentation.

Fixes https://github.com/projectcalico/node/issues/512

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that calico/node required IP auto detection to be enabled
```
