### PR TITLE
Introduce detection method cidr

### DIFF
--- a/pkg/allocateip/allocateip.go
+++ b/pkg/allocateip/allocateip.go
@@ -532,7 +532,7 @@ func removeHostTunnelAddr(ctx context.Context, c client.Interface, nodename stri
 			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); !ok {
 				// Unknown error releasing the address.
 				logCtx.WithError(err).WithFields(log.Fields{
-					"IP": ipAddrStr,
+					"IP":     ipAddrStr,
 					"Handle": handle,
 				}).Fatal("Error releasing address by handle")
 			}

--- a/pkg/startup/autodetection/filtered_test.go
+++ b/pkg/startup/autodetection/filtered_test.go
@@ -14,6 +14,8 @@
 package autodetection_test
 
 import (
+	"github.com/projectcalico/libcalico-go/lib/net"
+
 	"github.com/projectcalico/node/pkg/startup/autodetection"
 
 	. "github.com/onsi/ginkgo"
@@ -30,6 +32,14 @@ var _ = Describe("Filtered enumeration tests", func() {
 				Expect(err).To(BeNil())
 				Expect(iface).ToNot(BeNil())
 				Expect(addr).ToNot(BeNil())
+			})
+
+			It("should have enumerated at least IP address for one given known network cidr", func() {
+				liface, laddr, err := autodetection.FilteredEnumeration(nil, nil, []net.IPNet{*addr.Network()}, 4)
+				Expect(err).To(BeNil())
+				Expect(liface).NotTo(BeNil())
+				Expect(liface.Name).To(Equal(iface.Name))
+				Expect(laddr).To(Equal(addr))
 			})
 		})
 	})

--- a/pkg/startup/autodetection/filtered_test.go
+++ b/pkg/startup/autodetection/filtered_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Filtered enumeration tests", func() {
 	Describe("No filters", func() {
 		Context("Get interface and address", func() {
 
-			iface, addr, err := autodetection.FilteredEnumeration(nil, nil, 4)
+			iface, addr, err := autodetection.FilteredEnumeration(nil, nil, nil, 4)
 			It("should have enumerated at least one IP address", func() {
 				Expect(err).To(BeNil())
 				Expect(iface).ToNot(BeNil())

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -38,9 +38,6 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/selector"
 	"github.com/projectcalico/libcalico-go/lib/upgrade/migrator"
 	"github.com/projectcalico/libcalico-go/lib/upgrade/migrator/clients"
-	"github.com/projectcalico/node/pkg/calicoclient"
-	"github.com/projectcalico/node/pkg/startup/autodetection"
-	"github.com/projectcalico/node/pkg/startup/autodetection/ipv4"
 	log "github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -48,6 +45,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/projectcalico/node/pkg/calicoclient"
+	"github.com/projectcalico/node/pkg/startup/autodetection"
+	"github.com/projectcalico/node/pkg/startup/autodetection/ipv4"
 )
 
 const (
@@ -60,6 +61,7 @@ const (
 	AUTODETECTION_METHOD_CAN_REACH      = "can-reach="
 	AUTODETECTION_METHOD_INTERFACE      = "interface="
 	AUTODETECTION_METHOD_SKIP_INTERFACE = "skip-interface="
+	AUTODETECTION_METHOD_CIDR           = "cidr="
 
 	// KubeadmConfigConfigMap is defined in k8s.io/kubernetes, which we can't import due to versioning issues.
 	KubeadmConfigConfigMap = "kubeadm-config"
@@ -630,6 +632,15 @@ func autoDetectCIDR(method string, version int) *cnet.IPNet {
 		// Regexes are passed in as a string separated by ","
 		ifRegexes := regexp.MustCompile(`\s*,\s*`).Split(ifStr, -1)
 		return autoDetectCIDRByInterface(ifRegexes, version)
+	} else if strings.HasPrefix(method, AUTODETECTION_METHOD_CIDR) {
+		// Autodetect the IP by filtering interface by its address.
+		cidrStr := strings.TrimPrefix(method, AUTODETECTION_METHOD_CIDR)
+		// CIDRs are passed in as a string separated by ","
+		matches:=[]cnet.IPNet{}
+		for _, r:= range regexp.MustCompile(`\s*,\s*`).Split(cidrStr, -1) {
+			matches=append(matches, cnet.MustParseCIDR(r))
+		}
+		return autoDetectCIDRByCIDR(matches, version)
 	} else if strings.HasPrefix(method, AUTODETECTION_METHOD_CAN_REACH) {
 		// Autodetect the IP by connecting a UDP socket to a supplied address.
 		destStr := strings.TrimPrefix(method, AUTODETECTION_METHOD_CAN_REACH)
@@ -655,7 +666,7 @@ func autoDetectCIDR(method string, version int) *cnet.IPNet {
 func autoDetectCIDRFirstFound(version int) *cnet.IPNet {
 	incl := []string{}
 
-	iface, cidr, err := autodetection.FilteredEnumeration(incl, DEFAULT_INTERFACES_TO_EXCLUDE, version)
+	iface, cidr, err := autodetection.FilteredEnumeration(incl, DEFAULT_INTERFACES_TO_EXCLUDE, nil, version)
 	if err != nil {
 		log.Warnf("Unable to auto-detect an IPv%d address: %s", version, err)
 		return nil
@@ -669,13 +680,27 @@ func autoDetectCIDRFirstFound(version int) *cnet.IPNet {
 // autoDetectCIDRByInterface auto-detects the first valid Network on the interfaces
 // matching the supplied interface regex.
 func autoDetectCIDRByInterface(ifaceRegexes []string, version int) *cnet.IPNet {
-	iface, cidr, err := autodetection.FilteredEnumeration(ifaceRegexes, nil, version)
+	iface, cidr, err := autodetection.FilteredEnumeration(ifaceRegexes, nil, nil, version)
 	if err != nil {
 		log.Warnf("Unable to auto-detect an IPv%d address using interface regexes %v: %s", version, ifaceRegexes, err)
 		return nil
 	}
 
 	log.Infof("Using autodetected IPv%d address %s on matching interface %s", version, cidr.String(), iface.Name)
+
+	return cidr
+}
+
+// autoDetectCIDRByCIDR auto-detects the first valid Network on the interfaces
+// matching the supplied cidr.
+func autoDetectCIDRByCIDR(matches []cnet.IPNet, version int) *cnet.IPNet {
+	iface, cidr, err := autodetection.FilteredEnumeration(nil, nil, matches, version)
+	if err != nil {
+		log.Warnf("Unable to auto-detect an IPv%d address using interface cidr %s: %s", version, matches, err)
+		return nil
+	}
+
+	log.Infof("Using autodetected IPv%d address %s on interface %s matching cidrs %+v", version, cidr.String(), iface.Name, matches)
 
 	return cidr
 }
@@ -699,7 +724,7 @@ func autoDetectCIDRBySkipInterface(ifaceRegexes []string, version int) *cnet.IPN
 	excl := DEFAULT_INTERFACES_TO_EXCLUDE
 	excl = append(excl, ifaceRegexes...)
 
-	iface, cidr, err := autodetection.FilteredEnumeration(incl, excl, version)
+	iface, cidr, err := autodetection.FilteredEnumeration(incl, excl, nil, version)
 	if err != nil {
 		log.Warnf("Unable to auto-detect an IPv%d address while excluding %v: %s", version, ifaceRegexes, err)
 		return nil

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -636,9 +636,14 @@ func autoDetectCIDR(method string, version int) *cnet.IPNet {
 		// Autodetect the IP by filtering interface by its address.
 		cidrStr := strings.TrimPrefix(method, AUTODETECTION_METHOD_CIDR)
 		// CIDRs are passed in as a string separated by ","
-		matches:=[]cnet.IPNet{}
-		for _, r:= range regexp.MustCompile(`\s*,\s*`).Split(cidrStr, -1) {
-			matches=append(matches, cnet.MustParseCIDR(r))
+		matches := []cnet.IPNet{}
+		for _, r := range regexp.MustCompile(`\s*,\s*`).Split(cidrStr, -1) {
+			_, cidr, err := cnet.ParseCIDR(r)
+			if err != nil {
+				log.Errorf("Invalid CIDR %q for IP autodetection method: %s", r, method)
+				return nil
+			}
+			matches = append(matches, *cidr)
 		}
 		return autoDetectCIDRByCIDR(matches, version)
 	} else if strings.HasPrefix(method, AUTODETECTION_METHOD_CAN_REACH) {


### PR DESCRIPTION
## Description
New Feature: Offer a new detection method for a node's primary IP and interface.

The current implementation typically fails to identify the correct primary interface, if there is a tun/tap device already present if the lookup is done. It then finds the tun device and the rest of the node setup is done incorrectly.

So far, there is only one way to avoid this: use of the detection method `interface`, but it requires to know the interface name, which is typically operating system specific. To avoid this in a more generic setup as it is done for example in the [gardener](https://github.com/gardener/gardener) scenario it would be helpful to be able to identify the interface and IP address by a node IP range, that is typically given in an operating system independent manner and already known, when the nodes of a Kubernetes cluster are created.

Therefore this PR implements the detection method `cidr`, which allows to specify IP ranges (given by CIDRs). The first interface is selected, which matches one of the given ranges.

The already existing function `FilteredEnumeration` is just extended by an optional additional filter condition using CIDRs and the `Contains` method of the `net.IPNet` structure.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
A new IP/interface detection method `cidr` is added. The syntax (for example for the environment variable `IP_AUTODETECTION_METHOD` is `cidr=<cidr>(,<cidr>)*`.
```
