### PR TITLE
Attempt to clean up as many base image files as possible

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # Ignore everything except:
 *
 # - The filesystem that gets copied in and the generated binaries
+!clean-up-filesystem.sh
 !filesystem
 !dist/bin
 !vendor/github.com/kelseyhightower/confd/etc/calico/confd

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -93,20 +93,14 @@ RUN wget -P /tmp http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz && \
     cd /tmp/admin/runit-${RUNIT_VER}/ && \
     package/install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-407
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1 as ubi
 ARG ARCH
 ARG GIT_VERSION
 ARG IPTABLES_VER
 ARG RUNIT_VER
 
-# Required labels for certification
-LABEL name="Calico node" \
-      vendor="Project Calico" \
-      version=$GIT_VERSION \
-      release="1" \
-      summary="Calico node handles networking and policy for Calico" \
-      description="Calico node handles networking and policy for Calico" \
-      maintainer="laurence@tigera.io"
+# Update base packages to pick up security updates.  Must do this before adding the centos repo.
+RUN microdnf update
 
 # Copy in runit binaries
 COPY --from=centos  /tmp/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
@@ -118,9 +112,14 @@ COPY --from=centos  /root/rpmbuild/RPMS/${ARCH}/* /tmp/rpms/
 # Since the ubi repos do not contain all the packages we need (they're missing conntrack-tools),
 # we're using CentOS repos for all our packages. Using packages from a single source (CentOS) makes
 # it less likely we'll run into package dependency version mismatches.
+#
+# NOTE: new packages need to be added to the keep-list in clean-up-filesystem.sh.
 COPY centos.repo /etc/yum.repos.d/
 RUN rm /etc/yum.repos.d/ubi.repo && \
+    touch /in-the-container && \
     microdnf install \
+    # Don't install copious docs.
+    --setopt=tsflags=nodocs \
     # Needed for iptables
     libpcap libmnl libnfnetlink libnftnl libnetfilter_conntrack \
     ipset \
@@ -137,7 +136,9 @@ RUN rm /etc/yum.repos.d/ubi.repo && \
     libnetfilter_cthelper libnetfilter_cttimeout libnetfilter_queue \
     conntrack-tools \
     # Needed for runit startup script
-    which && \
+    which \
+    # Needed for the cleanup script
+    findutils && \
     microdnf clean all && \
     # Install iptables via rpms. The libs must be force installed because the iptables source RPM has the release
     # version '9.el8_0.1' while the existing iptables-libs (pulled in by the iputils package) has version '9.el8.1'.
@@ -157,16 +158,38 @@ COPY --from=bird /bird* /bin/
 # Copy in the filesystem - this contains felix, calico-bgp-daemon, licenses, etc...
 COPY filesystem/ /
 
-# Add symlink to modprobe where iptables expects it to be.
-# This has to come after copying over filesystem/, since that may overwrite /sbin depending on the base image.
-RUN ln -s /usr/sbin/modprobe /sbin/modprobe
+# On UBI, /sbin/ is a symlink so the above copy clobbers it; restore /sbin as symlinks (some binaries and
+# scripts hard-code /sbin/xyz, for example.
+RUN ln -s /usr/sbin/* /sbin/
 
-# Add in top-level license file
-COPY LICENSE /licenses
+COPY --from=bpftool /bpftool /bin
 
 # Copy in the calico-node binary
 COPY dist/bin/calico-node-amd64 /bin/calico-node
 
-COPY --from=bpftool /bpftool /bin
+# Clean out as many files as we can from the filesystem.  We no longer need dnf or the platform python install
+# or any of its dependencies.
+ADD clean-up-filesystem.sh /
+RUN /clean-up-filesystem.sh
+
+# Copy everything into a fresh scratch image so that naive CVE scanners don't pick up binaries and libraries
+# that have been removed in our later layers.
+FROM scratch
+COPY --from=ubi / /
+
+# Add in top-level license file
+COPY LICENSE /licenses
 
 CMD ["start_runit"]
+
+# Required labels for certification
+LABEL name="Calico node" \
+      vendor="Project Calico" \
+      version=$GIT_VERSION \
+      release="1" \
+      summary="Calico node handles networking and policy for Calico" \
+      description="Calico node handles networking and policy for Calico" \
+      maintainer="laurence@tigera.io"
+
+# Tell sv where to find the services.
+ENV SVDIR=/etc/service/enabled

--- a/clean-up-filesystem.sh
+++ b/clean-up-filesystem.sh
@@ -1,0 +1,355 @@
+#!/bin/bash
+# Copyright (c) 2020 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script attempts to clean up the container file system to remove as many
+# packages, binaries and libraries as possible.  It scans a keep-list of binaries
+# to find what libraries they reference; removes all but a keep-list of packages
+# and then removes any left-over binaries and libraries.
+
+set -e
+
+# Sanity check: the file is created by the Dockerfile.
+if [ ! -f /in-the-container ]; then
+  echo "You really don't want to run this outside the container!"
+  exit 1
+fi
+
+# List of directories to scan for binaries so that we can find out what libraries they link to.
+bin_dirs=(
+  # /bin is symlinked on UBI so only need the /usr version.
+  /sbin
+  /usr/bin
+  /usr/sbin
+  /usr/local/bin
+)
+
+# List of grep regex patterns to cover the binaries that we want to keep in the image.  We'll
+# scan these binaries to find the libraries they link to below.
+bin_allow_list_patterns=(
+  # Our binaries.
+  calico
+  bird
+  versions
+
+  # Init daemon.
+  runit
+  runsv
+  sv
+  utmpset
+
+  # Felix dependencies.
+  '/arp$'       # Used to add arp entries
+  '/conntrack$' # Used to remove conntrack entries.
+  '/ip$' # iproute2; used to add/manipulate routes etc.
+  bpftool
+
+  # iptables/ip sets
+  xtables
+  iptables
+  ip6tables
+  ipset
+
+  # kmod is a multi-binary backing depmod/insmod/etc; used by iptables
+  kmod depmod insmod modinfo modprobe rmmod lsmod
+
+  # Shell and basic shell tools; needed for runit.
+  '\['
+  alias
+  basename
+  coreutils
+  '/bash$'
+  '/sh$'
+  '/cat$'
+  '/cd$'
+  '/cp$'
+  '/ln$'
+  '/date$'
+  '/ls$'
+  echo
+  '/env$'
+  false
+  true
+  getopt
+  '/hostname$'
+  '/gzip$'
+  '/grep$'
+  '/nice$'
+  join
+  '/kill$'
+  mkdir
+  mknod
+  more
+  less
+  printf
+  '/read$'
+  readlink
+  '/rm$'
+  '/sed$'
+  sleep
+  sort
+  '/stat$'
+  tail
+  '/tc$'
+  touch
+  '/tee$'
+  timeout
+  '/test$'
+  ulimit
+  uniq
+  wait
+  which
+  whoami
+  yes
+  zcat
+  zless
+  zmore
+
+  # Used by this script.
+  '/find$'
+  '/ldd$'
+  '/ldconfig$'
+)
+
+# Convert the binary allow list into arguments for grep.
+declare -a grep_args
+i=0
+for pattern in "${bin_allow_list_patterns[@]}"; do
+  grep_args[$i]="-e"
+  grep_args[((i + 1))]=${pattern}
+  ((i += 2))
+done
+
+# Use an associative array as a set, we collect the paths of the binaries that we want
+# to keep as keys in the array.
+echo "Finding binaries that we want to keep:"
+declare -A binaries_to_keep
+while read -r path; do
+  echo "KEEP: $path"
+  binaries_to_keep[$path]=true
+done < <(find "${bin_dirs[@]}" \( -type f -or -type l \) | grep "${grep_args[@]}")
+
+
+# find-libs analyses a binary and prints a list of the names of the library .so files that
+# it uses (excluding path).
+find-libs() {
+  b=$1
+  # We'll use the keys of this map as a set in order to dedupe the filenames.
+  local -A libs
+  ldd=$(ldd "$b" 2>/dev/null || true)
+  # Avoid parsing ldd errors as lists of libs.
+  if [[ "$ldd" =~ not\ a\ dynamic|statically\ linked ]]; then
+    return
+  fi
+  # ldd output looks like this:
+  # 	linux-vdso.so.1 (0x00007f873e1d3000)
+  #		libselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x00007f873e161000)
+  # Ignore the "=>" and the parenthesized address; slurp up the other names.
+  # I'm not sure if the RHS of the => can ever have a different name so we add them
+  # both to the set.
+  for part in $ldd; do
+    if [[ "$part" =~ \( ]]; then
+      continue
+    fi
+    if [[ "$part" == "=>" ]]; then
+      continue
+    fi
+    libs["$(basename "${part}")"]=true
+  done
+  # Dump the keys of the map that we use as a set.
+  echo "${!libs[@]}"
+}
+
+# Use an associative array as a set, building up the set of in-use libraries.
+# Note: "${!binaries_to_keep[@]}" expands to the keys of the associative array.
+echo "Finding in-use libraries:"
+declare -A libs
+for b in "${!binaries_to_keep[@]}"; do
+  printf "%s -> " "$b"
+  for lib in $(find-libs "$b"); do
+    printf "%s " "${lib}"
+    libs[${lib}]=true
+  done
+  printf "\n"
+done
+echo
+
+# Libraries are usually symlinked.  Expand the set of allowed libraries to include
+# the targets of symlinks (or we'd keep the symlink and delete the actual library!).
+echo "Analysing library symlinks..."
+while read -r path; do
+  file=$(basename "${path}")
+  target_path=$(readlink "$path" || true)
+  if [[ -z "$target_path" ]] || [[ "$target_path" = "${path}" ]]; then
+    continue
+  fi
+  target_file=$(basename "${target_path}")
+  if [[ -n "${libs[${file}]}" ]] && [[ -z "${libs[${target_file}]}" ]]; then
+    echo "${file} -> ${target_file}"
+    libs[${target_file}]=true
+  fi
+done < <(find /usr/lib64 \( -type l \))
+echo
+
+# We only capture the filenames of the libraries above, search for the paths.
+echo "Resolving in-use libraries to paths..."
+declare -A libs_to_keep
+while read -r path; do
+  file=$(basename "${path}")
+  if [[ -n "${libs[${file}]}" ]]; then
+    echo "IN USE: $path"
+    libs_to_keep[$path]=true
+    continue
+  fi
+  # Well-known plugins, not directly linked.
+  if [[ "$path" =~ xtables|netfilter|conntrack|ct_|pam|libnss ]] && ! [[ "$path" =~ systemd ]] ; then
+    echo "PLUGIN: $path"
+    libs_to_keep[$path]=true
+    continue
+  fi
+done < <(find /usr/lib64 \( -type f -or -type l \))
+
+# Now remove all but a keep-list of RPM packages.  Cleaning up packages with rpm itself updates the
+# metadata that CVE scanners look for so it's best to do this before we clean up any remaining
+# binaries and libraries that we don't want.
+packages_to_keep=(
+  bash
+  ca-certificates
+  conntrack-tools
+  coreutils-single
+  crypto-policies
+  filesystem
+  findutils
+  glibc
+  grep
+  gzip
+  iproute
+  ipset
+  iptables
+  kmod
+  langpacks
+  libacl
+  libattr
+  libcap
+  libcrypto
+  libelf
+  libgcc
+  libmnl
+  libnetfilter
+  libnfnetlink
+  libnftnl
+  libnss
+  libpcap
+  libpwquality
+  libselinux
+  libzstd
+  ncurses
+  net-tools
+  openssl-libs
+  p11-kit-trust
+  pam
+  pcre
+  redhat-release
+  rootfiles
+  rpm
+  sed
+  shadow-utils
+  shared-mime-info
+  systemd-libs
+  tzdata
+  util-linux
+  which
+  xz-libs
+  zlib
+)
+
+# Convert the keep list into arguments for grep.
+declare -a grep_args
+i=0
+for pattern in "${packages_to_keep[@]}"; do
+  grep_args[$i]="-e"
+  grep_args[((i + 1))]=${pattern}
+  ((i += 2))
+done
+
+# List all the packages and use an inverse grep to filter out the ones that we want to
+# keep.  The output from microdnf repoquery includes the full version of each package
+# but rpm only wants the package name, not its version.
+#
+# Example:
+#  "audit-libs-3.0-0.17.20191104git1c2f876.el8.x86_64" -> "audit-libs"
+#
+# Use sed to extract everything up to the version.  The regex matches dash-separated
+# words at the start of the line, where a word must begin with an alphabetic character.
+# This allows things like "krb5" but disallows "1.2.3"
+packages_to_remove=$(microdnf repoquery --installed |
+  sed -e 's/^\(\([a-zA-Z][a-zA-Z0-9_+]*\)\(-\([a-zA-Z][a-zA-Z0-9_+]*\)\)*\).*/\1/g' |
+  grep -v "${grep_args[@]}")
+
+
+echo "Removing ${packages_to_remove}"
+# Removing one of the packages deletes rc.local, move it out of the way.
+mv /etc/rc.local /etc/rc.local.bak
+rpm -e --nodeps $packages_to_remove
+mv /etc/rc.local.bak /etc/rc.local
+
+# Sanity check that we didn't remove anything we want to keep.
+for path in "${!binaries_to_keep[@]}"; do
+  if [[ -e "$path" ]]; then
+    continue
+  fi
+  echo "Binary is missing after RPM cleanup: $path"
+  exit 1
+done
+for path in "${!libs_to_keep[@]}"; do
+  if [[ -e "$path" ]]; then
+    continue
+  fi
+  echo "Library is missing after RPM cleanup: $path"
+  exit 1
+done
+
+# Then delete any binaries and libraries that we don't want to keep.
+while read -r path; do
+  if [[ -n "${binaries_to_keep[$path]}" ]]; then
+    continue
+  fi
+  echo "DEL: $path"
+  rm -f "$path"
+done < <(find "${bin_dirs[@]}" \( -type f -or -type l \))
+
+while read -r path; do
+  if [[ -n "${libs_to_keep[$path]}" ]]; then
+    continue
+  fi
+  echo "DEL: $path"
+  rm -f "$path"
+done < <(find /usr/lib64 \( -type f -or -type l \))
+
+# We deleted a lot of libraries, update the cache.
+rm /etc/ld.so.cache
+ldconfig
+
+# Delete some easy pickings: caches, X, RPMs, this script!
+rm -rf \
+  /var/cache/* \
+  /tmp/rpms \
+  '@System.solv' \
+  /etc/X11 \
+  /usr/share/gcc-8 \
+  /usr/share/X11 \
+  /usr/share/zsh \
+  /in-the-container \
+  /usr/bin/ldd \
+  "$0"

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 )
 
 replace (
-	github.com/kelseyhightower/confd => github.com/projectcalico/confd v1.0.1-0.20200618080843-c3ceea1211fc
+	github.com/kelseyhightower/confd => github.com/projectcalico/confd v1.0.1-0.20200626131600-30019b51f87c
 
 	github.com/sirupsen/logrus => github.com/projectcalico/logrus v1.0.4-calico
 

--- a/go.sum
+++ b/go.sum
@@ -540,6 +540,8 @@ github.com/projectcalico/confd v1.0.1-0.20200616080643-881884210e43 h1:dMxdBvlCy
 github.com/projectcalico/confd v1.0.1-0.20200616080643-881884210e43/go.mod h1:qBtH7JgApkdf71XLoxsYl7pDfXzAW14kQv8AbGZOdWg=
 github.com/projectcalico/confd v1.0.1-0.20200618080843-c3ceea1211fc h1:KeXh+wuDACpcJNtSUH7+YY70Nl5H0287p/yAaGV2V18=
 github.com/projectcalico/confd v1.0.1-0.20200618080843-c3ceea1211fc/go.mod h1:4SdywFVDRLJguQKXBwi1Iw7ddp+l5CRJJlxFauhrtNc=
+github.com/projectcalico/confd v1.0.1-0.20200626131600-30019b51f87c h1:hfEl0XeS07MOZ7vfX4KEKcYonKcrLz4MDI2a8REXALY=
+github.com/projectcalico/confd v1.0.1-0.20200626131600-30019b51f87c/go.mod h1:4SdywFVDRLJguQKXBwi1Iw7ddp+l5CRJJlxFauhrtNc=
 github.com/projectcalico/felix v0.0.0-20200611144157-d4d227ee6ea9 h1:jdOUNFsxWkeZXOYreaXXrCDBSXkeFFICNieYH9bUuYs=
 github.com/projectcalico/felix v0.0.0-20200611144157-d4d227ee6ea9/go.mod h1:4yvmYJ4+kgYQ+P74MLQjTqj8v3qSQ1VQI/YJ7J0TCmo=
 github.com/projectcalico/felix v0.0.0-20200612003414-17921cc56a95 h1:m9swjqTW67Tuis8vr6xiL+yb7vEjLOs2tvT1Hf0sciw=

--- a/tests/st/bgp/test_bgp.py
+++ b/tests/st/bgp/test_bgp.py
@@ -185,8 +185,8 @@ class TestReadiness(TestBase):
             # Block bgp connectivity between hosts
             host1.execute("iptables -t raw -I PREROUTING  -p tcp -m multiport --dport 179 -j DROP")
             host2.execute("iptables -t raw -I PREROUTING -p tcp -m multiport --dport 179 -j DROP")
-            host1.execute("docker exec -it calico-node pkill -9 bird")
-            host2.execute("docker exec -it calico-node pkill -9 bird")
+            host1.execute("docker exec -it calico-node sv kill bird")
+            host2.execute("docker exec -it calico-node sv kill bird")
 
             # Check that the readiness script is reporting 'not ready'
             self.assertRaisesRegexp(CalledProcessError, "calico/node is not ready: BIRD is not ready: BGP not established with",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

After installing on top of UBI, run a cleanup script that strips out as much as possible.  The script:

- Starts with an allow list of binaries.
- Uses ldd to find all their library dependencies.
- Removes all but a keep-list of RPMs.
- Deletes any remaining unwanted binaries.
- Deletes libraries that are not referenced by the allowed binaries.

The allow list doesn't include pkill, because it pulls in a libsystemd, which has CVEs that we want to avoid. Hence, I've switched uses of pkill over to use `sv <signal> <service>`.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
calico/node's security has been improved by removing as many unneeded packages, binaries and libraries from the base image as possible.
```
