### PR TITLE
Fix issue when remote_deps generated twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ remote-deps: mod-download
 	# Recreate the directory so that we are sure to clean up any old files.
 	rm -rf filesystem/etc/calico/confd
 	mkdir -p filesystem/etc/calico/confd
+	rm -rf config
 	rm -rf bin/bpf
 	mkdir -p bin/bpf
 	rm -rf filesystem/usr/lib/calico/bpf/


### PR DESCRIPTION
## Description
If `make remote_deps` is run twice in a row without running `make clean`, `/node/config/config/...` is created, possibly preventing some changes from being applied.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
