### PR TITLE
Fixed s390x native build

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -18,40 +18,11 @@ ARG BIRD_IMAGE=calico/bird:latest
 FROM ${QEMU_IMAGE} as qemu
 FROM ${BIRD_IMAGE} as bird
 
-FROM s390x/debian:buster-slim as bpftool-build
+FROM calico/bpftool:v5.3-s390x as bpftool
 
-COPY --from=qemu /usr/bin/qemu-s390x-static /usr/bin/
-
-RUN apt-get update && \
-apt-get upgrade -y && \
-apt-get install -y --no-install-recommends \
-    gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-8-dev \
-    bash-completion binutils binutils-dev make git curl \
-    ca-certificates xz-utils gcc pkg-config bison flex build-essential && \
-apt-get purge --auto-remove && \
-apt-get clean
-
-WORKDIR /tmp
-
-RUN \
-git clone --depth 1 -b master git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git && \
-cd linux/tools/bpf/bpftool/ && \
-sed -i '/CFLAGS += -O2/a CFLAGS += -static' Makefile && \
-sed -i 's/LIBS = -lelf $(LIBBPF)/LIBS = -lelf -lz $(LIBBPF)/g' Makefile && \
-printf 'feature-libbfd=0\nfeature-libelf=1\nfeature-bpf=1\nfeature-libelf-mmap=1' >> FEATURES_DUMP.bpftool && \
-FEATURES_DUMP=`pwd`/FEATURES_DUMP.bpftool make -j `getconf _NPROCESSORS_ONLN` && \
-strip bpftool && \
-ldd bpftool 2>&1 | grep -q -e "Not a valid dynamic program" \
-	-e "not a dynamic executable" || \
-	( echo "Error: bpftool is not statically linked"; false ) && \
-mv bpftool /usr/bin && rm -rf /tmp/linux
-
-FROM s390x/alpine:3.8
-MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
+FROM s390x/alpine:3.8 as base
 
 ARG ARCH=s390x
-# Set the minimum required Docker API version.
-ENV DOCKER_API_VERSION 1.21
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
@@ -71,7 +42,7 @@ COPY filesystem/ /
 # Copy in the calico-node binary
 COPY dist/bin/calico-node-${ARCH} /bin/calico-node
 
-COPY --from=bpftool-build /usr/bin/bpftool /bin
+COPY --from=bpftool /bpftool /bin
 
 RUN rm /usr/bin/qemu-${ARCH}-static
 

--- a/calico_test/Dockerfile.s390x.calico_test
+++ b/calico_test/Dockerfile.s390x.calico_test
@@ -59,7 +59,7 @@ RUN apk update \
 
 # Install etcdctl
 COPY pkg /pkg/
-RUN tar -xzf pkg/etcd-v3.3.1-linux-s390x.tar.gz -C /usr/local/bin/
+RUN tar -xzf pkg/etcd-v3.3.7-linux-s390x.tar.gz -C /usr/local/bin/
 
 # The container is used by mounting the code-under-test to /code
 WORKDIR /code/

--- a/workload/Dockerfile.s390x
+++ b/workload/Dockerfile.s390x
@@ -1,10 +1,9 @@
 # The Dockerfile-s390x is copied from node/workload/Dockerfile.
 # Modifications done includes:
-# 1) Base image has been changed FROM alpine:3.8 to FROM s390x/alpine:3.6
+# 1) Base image has been changed FROM alpine:3.6 to FROM s390x/alpine:3.8
 # 2) Maintainer is changed
 
-FROM s390x/alpine:3.6
-MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
+FROM s390x/alpine:3.8
 
 RUN apk add --no-cache \
     python \


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include

-->
Updated Dockerfile.s390x as in sync of Dockerfiles of other architectures to use bpftool image instead of building it inside Dockerfile.s390x of node, updated etcd version in calico_test/Dockerfile.s390x.calico_test, updated alpine version to 3.8 in workload/Dockerfile.s390x.
This will enable the s390x native build.
Tested native build for s390x, CI does not have s390x cross-build support yet.
which components are affected by this PR: Node module for s390x

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
