### PR TITLE
Use calicoctl-wait instead of now non-existent shell, in calicoctl image

### DIFF
--- a/tests/k8st/infra/calicoctl-etcd.yaml
+++ b/tests/k8st/infra/calicoctl-etcd.yaml
@@ -15,7 +15,7 @@ spec:
   containers:
   - name: calicoctl
     image: calico/ctl:master
-    command: ["/bin/sh", "-c", "while true; do sleep 3600; done"]
+    command: ["/calicoctl-wait"]
     env:
     - name: ETCD_ENDPOINTS
       valueFrom:

--- a/tests/k8st/infra/calicoctl.yaml
+++ b/tests/k8st/infra/calicoctl.yaml
@@ -24,7 +24,7 @@ spec:
   containers:
   - name: calicoctl
     image: calico/ctl:master
-    command: ["/bin/sh", "-c", "while true; do sleep 3600; done"]
+    command: ["/calicoctl-wait"]
     env:
     - name: DATASTORE_TYPE
       value: kubernetes
@@ -103,4 +103,3 @@ subjects:
 - kind: ServiceAccount
   name: calicoctl
   namespace: kube-system
-


### PR DESCRIPTION
Should fix our `make k8s-test` CI which is currently broken, e.g. https://tigera.semaphoreci.com/jobs/df1c7a87-72da-4ccc-95c9-8fba07328a4c