### PR TITLE
Automated cherry pick of #536: Update go-build version to v0.45

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE_NAME?=github.com/projectcalico/node
-GO_BUILD_VER?=v0.40
+GO_BUILD_VER?=v0.45
 
 # This needs to be evaluated before the common makefile is included.
 # This var contains some default values that the common makefile may append to.


### PR DESCRIPTION
Cherry pick of #536 on release-v3.15.

#536: Update go-build version to v0.45