### PR TITLE
Test IPv4 and IPv6 floating IP assignment with dual stack

### DIFF
--- a/tests/k8st/create_kind_cluster.sh
+++ b/tests/k8st/create_kind_cluster.sh
@@ -39,6 +39,12 @@ function enable_dual_stack() {
 EOF
   sed -i -e 's/"type": "calico-ipam"/"type": "calico-ipam",/' "${yaml}"
 
+  sed -i -e '/"type": "calico"/r /dev/stdin' "${yaml}" <<EOF
+     "feature_control": {
+         "floating_ips": true
+     },
+EOF
+
   # And add all the IPV6 env vars
   sed -i '/# Enable IPIP/r /dev/stdin' "${yaml}" << EOF
             - name: IP6

--- a/tests/k8st/tests/test_simple.py
+++ b/tests/k8st/tests/test_simple.py
@@ -145,6 +145,7 @@ class TestSimplePolicy(TestBase):
         # the server pod - which can confuse test code that is
         # expecting connection failure for some other reason.
         kubectl("run --generator=run-pod/v1 access -n policy-demo" +
+                " --overrides='{\"metadata\": {\"annotations\": {\"cni.projectcalico.org/floatingIPs\":\"[\\\"195.160.168.193\\\", \\\"2001:67c:275c:ff::1\\\"]\"}}}' "
                 " --image busybox --command /bin/sleep -- 3600")
         kubectl("run --generator=run-pod/v1 no-access -n policy-demo" +
                 " --image busybox --command /bin/sleep -- 3600")


### PR DESCRIPTION
With these changes, and

    make k8s-test K8ST_TO_RUN=tests/test_simple.py:TestSimplePolicy

Prior to the CNI plugin fix at
https://github.com/projectcalico/cni-plugin/pull/922, the
test_simple_policy test failed with

    error: timed out waiting for the condition on pods/access

because the 'access' pod didn't start.  'kubectl describe' showed a
"mismatched IP versions" problem:

    Warning FailedCreatePodSandBox 12s (x5 over 60s) kubelet,
    kind-worker (combined from similar events): Failed to create pod
    sandbox: rpc error: code = Unknown desc = failed to setup network
    for sandbox
    "fede455cae2021942809745532d415bacd38214b94c86e4a85bc7d04418df9d6":
    error with field ExternalIP = '2001:67c:275c:ff::1' (mismatched IP
    versions)

Following the CNI plugin fix at
https://github.com/projectcalico/cni-plugin/pull/922, the test passes
again.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
