### PR TITLE
AUTODETECTION_METHOD_K8S option

### DIFF
--- a/pkg/startup/autodetection/kubernetes.go
+++ b/pkg/startup/autodetection/kubernetes.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package autodetection
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/net"
+	kapiv1 "k8s.io/api/core/v1"
+)
+
+func nodeAddresses(node *kapiv1.Node, addrType kapiv1.NodeAddressType) []string {
+	ret := make([]string, 0, 1)
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == addrType {
+			ret = append(ret, addr.Address)
+		}
+	}
+
+	return ret
+}
+
+// K8sNodeInternalIPs returns the internal IPs of the given version found in the k8s Node resource
+func K8sNodeInternalIPs(node *kapiv1.Node, version int) []*net.IPNet {
+	addrs := nodeAddresses(node, kapiv1.NodeInternalIP)
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	ret := make([]*net.IPNet, 0, len(addrs))
+	for _, a := range addrs {
+		ip, ipnet, err := net.ParseCIDROrIP(a)
+		if err == nil && ip.Version() == version {
+			ret = append(ret, ipnet)
+		}
+	}
+
+	return ret
+}


### PR DESCRIPTION
When running in kubernetes environment, provide the option to detect the
node addresses from the k8s node resource. This may give the most precise
autodetection option when in an environment with multiple NICs. This is
independent of the interface naming or reachability and is well suited
for runnig in policy only mode, e.g. on EKS with AWS CNI.

Precise node IP detection is necessary for eBPF to program its routes,
which then used, for instance, for connect time resolution of nodeports
both by the pods and hosts.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
