### PR TITLE
Conditionally terminate if IP isn't available under calico/node resource.

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -256,7 +256,7 @@ func configureAndCheckIPAddressSubnets(ctx context.Context, cli client.Interface
 			// Unrecoverable error, terminate to restart.
 			terminate()
 		} else {
-			log.Warn("No IPv4 or IPv6 addresses configured, and autodetection is not enabled. Some features may not work properly.")
+			log.Warn("No IPv4 or IPv6 addresses configured or detected. Some features may not work properly.")
 			// Bail here setting BGPSpec to nil (if empty) to pass validation.
 			if reflect.DeepEqual(node.Spec.BGP, &api.NodeBGPSpec{}) {
 				node.Spec.BGP = nil

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -250,6 +250,19 @@ func configureAndCheckIPAddressSubnets(ctx context.Context, cli client.Interface
 		terminate()
 	}
 
+	if node.Spec.BGP.IPv4Address == "" && node.Spec.BGP.IPv6Address == "" {
+		if os.Getenv("CALICO_NETWORKING_BACKEND") != "none" {
+			log.Error("No IP Addresses configured, and autodetection is not enabled")
+			// Unrecoverable if Calico is handling networking, terminate to restart.
+			terminate()
+		} else {
+			log.Warn("No IP Addresses configured, and autodetection is not enabled. Some features may not work properly.")
+			// Bail here setting node.Spec.BGP to nil so that the node validation passes.
+			node.Spec.BGP = nil
+			return checkConflicts
+		}
+	}
+
 	// If we report an IP change (v4 or v6) we should verify there are no
 	// conflicts between Nodes.
 	if checkConflicts && os.Getenv("DISABLE_NODE_IP_CHECK") != "true" {
@@ -551,11 +564,6 @@ func configureIPsAndSubnets(node *api.Node) (bool, error) {
 			node.Spec.BGP.IPv6Address = parseIPEnvironment("IP6", ipv6Env, 6)
 		}
 		validateIP(node.Spec.BGP.IPv6Address)
-	}
-
-	if ipv4Env == "none" && (ipv6Env == "" || ipv6Env == "none") && node.Spec.BGP.IPv4Address == "" && node.Spec.BGP.IPv6Address == "" {
-		log.Warn("No IP Addresses configured, and autodetection is not enabled")
-		terminate()
 	}
 
 	// Detect if we've seen the IP address change, and flag that we need to check for conflicting Nodes

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -250,6 +250,21 @@ func configureAndCheckIPAddressSubnets(ctx context.Context, cli client.Interface
 		terminate()
 	}
 
+	if node.Spec.BGP.IPv4Address == "" && node.Spec.BGP.IPv6Address == "" {
+		if os.Getenv("CALICO_NETWORKING_BACKEND") != "none" {
+			log.Error("No IPv4 or IPv6 addresses configured or detected, required for Calico networking")
+			// Unrecoverable error, terminate to restart.
+			terminate()
+		} else {
+			log.Warn("No IPv4 or IPv6 addresses configured, and autodetection is not enabled. Some features may not work properly.")
+			// Bail here setting BGPSpec to nil (if empty) to pass validation.
+			if reflect.DeepEqual(node.Spec.BGP, &api.NodeBGPSpec{}) {
+				node.Spec.BGP = nil
+			}
+			return checkConflicts
+		}
+	}
+
 	// If we report an IP change (v4 or v6) we should verify there are no
 	// conflicts between Nodes.
 	if checkConflicts && os.Getenv("DISABLE_NODE_IP_CHECK") != "true" {
@@ -551,11 +566,6 @@ func configureIPsAndSubnets(node *api.Node) (bool, error) {
 			node.Spec.BGP.IPv6Address = parseIPEnvironment("IP6", ipv6Env, 6)
 		}
 		validateIP(node.Spec.BGP.IPv6Address)
-	}
-
-	if ipv4Env == "none" && (ipv6Env == "" || ipv6Env == "none") && node.Spec.BGP.IPv4Address == "" && node.Spec.BGP.IPv6Address == "" {
-		log.Warn("No IP Addresses configured, and autodetection is not enabled")
-		terminate()
 	}
 
 	// Detect if we've seen the IP address change, and flag that we need to check for conflicting Nodes

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -75,6 +75,39 @@ func makeNode(ipv4 string, ipv6 string) *api.Node {
 	return n
 }
 
+var _ = DescribeTable("Node IP detection failure cases",
+	func(networkingBackend string, expectedExitCode int, rrCId string) {
+		os.Setenv("CALICO_NETWORKING_BACKEND", networkingBackend)
+		os.Setenv("IP", "none")
+		os.Setenv("IP6", "")
+
+		my_ec := 0
+		oldExit := exitFunction
+		exitFunction = func(ec int) { my_ec = ec }
+		defer func() { exitFunction = oldExit }()
+
+		// prologue for the main test.
+		cfg, err := apiconfig.LoadClientConfigFromEnvironment()
+		Expect(err).NotTo(HaveOccurred())
+		c, err := client.New(*cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		node := api.Node{}
+		if rrCId != "" {
+			node.Spec.BGP = &api.NodeBGPSpec{RouteReflectorClusterID: rrCId}
+		}
+		_ = configureAndCheckIPAddressSubnets(context.Background(), c, &node)
+		Expect(my_ec).To(Equal(expectedExitCode))
+		if rrCId != "" {
+			Expect(node.Spec.BGP).NotTo(BeNil())
+		}
+	},
+
+	Entry("startup should terminate if IP is set to none and Calico is used for networking", "bird", 1, ""),
+	Entry("startup should NOT terminate if IP is set to none and Calico is policy-only", "none", 0, ""),
+	Entry("startup should NOT terminate and BGPSpec shouldn't be set to nil", "none", 0, "rrClusterID"),
+)
+
 var _ = Describe("Default IPv4 pool CIDR", func() {
 
 	It("default pool must be valid", func() {

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -75,31 +75,6 @@ func makeNode(ipv4 string, ipv6 string) *api.Node {
 	return n
 }
 
-var _ = DescribeTable("Node IP detection failure cases",
-	func(networkingBackend string, expectedExitCode int) {
-		os.Setenv("CALICO_NETWORKING_BACKEND", networkingBackend)
-		os.Setenv("IP", "none")
-		os.Setenv("IP6", "")
-
-		my_ec := 0
-		oldExit := exitFunction
-		exitFunction = func(ec int) { my_ec = ec }
-		defer func() { exitFunction = oldExit }()
-
-		// prologue for the main test.
-		cfg, err := apiconfig.LoadClientConfigFromEnvironment()
-		Expect(err).NotTo(HaveOccurred())
-		c, err := client.New(*cfg)
-		Expect(err).NotTo(HaveOccurred())
-
-		_ = configureAndCheckIPAddressSubnets(context.Background(), c, &api.Node{})
-		Expect(my_ec).To(Equal(expectedExitCode))
-	},
-
-	Entry("startup should NOT terminate if IP is set to none and Calico is policy-only", "none", 0),
-	Entry("startup should terminate if IP is set to none and Calico is used for networking", "bird", 1),
-)
-
 var _ = Describe("Default IPv4 pool CIDR", func() {
 
 	It("default pool must be valid", func() {

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -75,6 +75,31 @@ func makeNode(ipv4 string, ipv6 string) *api.Node {
 	return n
 }
 
+var _ = DescribeTable("Node IP detection failure cases",
+	func(networkingBackend string, expectedExitCode int) {
+		os.Setenv("CALICO_NETWORKING_BACKEND", networkingBackend)
+		os.Setenv("IP", "none")
+		os.Setenv("IP6", "")
+
+		my_ec := 0
+		oldExit := exitFunction
+		exitFunction = func(ec int) { my_ec = ec }
+		defer func() { exitFunction = oldExit }()
+
+		// prologue for the main test.
+		cfg, err := apiconfig.LoadClientConfigFromEnvironment()
+		Expect(err).NotTo(HaveOccurred())
+		c, err := client.New(*cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		_ = configureAndCheckIPAddressSubnets(context.Background(), c, &api.Node{})
+		Expect(my_ec).To(Equal(expectedExitCode))
+	},
+
+	Entry("startup should NOT terminate if IP is set to none and Calico is policy-only", "none", 0),
+	Entry("startup should terminate if IP is set to none and Calico is used for networking", "bird", 1),
+)
+
 var _ = Describe("Default IPv4 pool CIDR", func() {
 
 	It("default pool must be valid", func() {


### PR DESCRIPTION
## Description

Conditionally terminate if IP isn't available under calico/node resource.
If calico isn't being used for networking, don't restart when IP address is not available under the resource.

## Todos
- [x] Tests: UT + tested in an EKS cluster (aws-vpc CNI) that calico-node doesn't crash.
- [ ] Documentation

## Release Note

```release-note
None required
```
