### PR TITLE
feature(Windows): Allow to automatically set etcd TLS config

### DIFF
--- a/windows-packaging/CalicoWindows/config.ps1
+++ b/windows-packaging/CalicoWindows/config.ps1
@@ -27,9 +27,9 @@ $env:KUBECONFIG = "c:\k\config"
 # For the "etcdv3" datastore only: set ETCD_ENDPOINTS, format: "http://<host>:<port>,..."
 $env:ETCD_ENDPOINTS = "<your etcd endpoints>"
 # For etcd over TLS, set these lines to point to your keys/certs:
-$env:ETCD_KEY_FILE = ""
-$env:ETCD_CERT_FILE = ""
-$env:ETCD_CA_CERT_FILE = ""
+$env:ETCD_KEY_FILE = "<your etcd key>"
+$env:ETCD_CERT_FILE = "<your etcd cert>"
+$env:ETCD_CA_CERT_FILE = "<your etcd ca cert>"
 
 
 ## CNI configuration, only used for the "vxlan" networking backends.


### PR DESCRIPTION
## Description
feature: Add "variables" to config of Calico for Windows to automatically get substituted by `install-calico-windows.ps1`, see https://github.com/projectcalico/calico/pull/3997

As Kubernetes clusters often get set up with etcd and TLS (e.g. per default via `kubeadm`), it makes sense to allow the user to automatically set this up instead of manually modifying the config file. 

The changes of this PR play together with the one from https://github.com/projectcalico/calico/pull/3997.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [] Tests - not needed
- [] Documentation - done, see https://github.com/projectcalico/calico/pull/3997
- [] Release note - not needed

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
