### PR TITLE
Fix DNS resolution in calico-node containers

### DIFF
--- a/clean-up-filesystem.sh
+++ b/clean-up-filesystem.sh
@@ -213,7 +213,7 @@ while read -r path; do
     continue
   fi
   # Well-known plugins, not directly linked.
-  if [[ "$path" =~ xtables|netfilter|conntrack|ct_|pam|libnss ]] && ! [[ "$path" =~ systemd ]] ; then
+  if [[ "$path" =~ xtables|netfilter|conntrack|ct_|pam|libnss|libresolv ]] && ! [[ "$path" =~ systemd ]] ; then
     echo "PLUGIN: $path"
     libs_to_keep[$path]=true
     continue


### PR DESCRIPTION
## Description
The `calico/node` image is missing the `libresolv.so.2` library: it gets deleted by the `clean-up-filesystem.sh` script because it's not directly linked to any binaries from the "keep" list.

This library is provided by the `glibc` package and is necessary for DNS resolution to work.
Without it, every `getaddrinfo()` call returns -11 (`EAI_SYSTEM`) and no names can be resolved from inside the `calico-node` containers.

If Calico is configured to use an external etcdv3 cluster as its datastore, this makes it impossible to use names instead of IP addresses in the etcd endpoint list.

This PR adds `libresolv` to the "well-known plugins" list so that it doesn't get cleaned up.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix DNS resolution in calico-node containers.
```
