### PR TITLE
windows: kube-services scripts support single service

### DIFF
--- a/windows-packaging/CalicoWindows/kubernetes/install-kube-services.ps1
+++ b/windows-packaging/CalicoWindows/kubernetes/install-kube-services.ps1
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+param
+(
+     [string][parameter(Mandatory=$false)]$service
+)
+
 # We require the 64-bit version of Powershell, which should live at the following path.
 $powerShellPath = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe"
 $baseDir = "$PSScriptRoot\.."
@@ -88,5 +93,23 @@ function Install-KubeProxyService()
     Write-Host "Done installing kube-proxy service."
 }
 
-Install-KubeletService
-Install-KubeProxyService
+if (($service -ne "") -and ($service -notin "kubelet", "kube-proxy"))
+{
+    Write-Host "Invalid -service value. Valid values are: 'kubelet' or 'kube-proxy'"
+    Exit
+}
+
+Write-Host the param is $service
+if ($service -eq "")
+{
+    Install-KubeletService
+    Install-KubeProxyService
+}
+elseif ($service -eq "kubelet")
+{
+    Install-KubeletService
+}
+else
+{
+    Install-KubeProxyService
+}

--- a/windows-packaging/CalicoWindows/kubernetes/uninstall-kube-services.ps1
+++ b/windows-packaging/CalicoWindows/kubernetes/uninstall-kube-services.ps1
@@ -12,15 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+param
+(
+     [string][parameter(Mandatory=$false)]$service
+)
+
 $baseDir = "$PSScriptRoot\.."
 $NSSMPath = "$baseDir\nssm-2.24\win64\nssm.exe"
 
 $ErrorActionPreference = 'SilentlyContinue'
 
-Write-Host "Stopping kubelet kube-proxy service if it is running..."
-Stop-Service kubelet
-Stop-Service kube-proxy
+if (($service -ne "") -and ($service -notin "kubelet", "kube-proxy"))
+{
+    Write-Host "Invalid -service value. Valid values are: 'kubelet' or 'kube-proxy'"
+    Exit
+}
 
-& $NSSMPath remove kube-proxy confirm
-& $NSSMPath remove kubelet confirm
-Write-Host "Done"
+if ($service -eq "")
+{
+    Write-Host "Stopping kubelet kube-proxy services if they are running..."
+    Stop-Service kubelet
+    Stop-Service kube-proxy
+    
+    & $NSSMPath remove kube-proxy confirm
+    & $NSSMPath remove kubelet confirm
+    Write-Host "Done"
+}
+else
+{
+    Write-Host "Stopping $service service if it is running..."
+    Stop-Service $service
+    & $NSSMPath remove $service confirm
+    Write-Host "Done"
+}


### PR DESCRIPTION
Description

This PR makes the kube-services install/uninstall scripts also support a single service. Some platforms only need kube-proxy installed by our scripts. The in-progress OCP+CalicoWindows installation docs PR uses install-kube-proxy.ps1: https://github.com/projectcalico/calico/pull/4058/commits/c3109661867c96ca67a3a0813c61e7b8e41e03b8

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->
```release-note
```
