### PR TITLE
Automatically find the cidr of IPv4Address when IP is ipStr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ endif
 	docker run --rm -v $(CURDIR)/dist/bin:/go/bin:rw $(CALICO_BUILD) /bin/sh -c "\
 	  echo; echo calico-node-$(ARCH) -v;	 /go/bin/calico-node-$(ARCH) -v; \
 	"
-	docker build -t $(BUILD_IMAGE):latest-$(ARCH) . --build-arg BIRD_IMAGE=$(BIRD_IMAGE) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./Dockerfile.$(ARCH)
+	docker build --pull -t $(BUILD_IMAGE):latest-$(ARCH) . --build-arg BIRD_IMAGE=$(BIRD_IMAGE) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./Dockerfile.$(ARCH)
 	touch $@
 
 # download BIRD source to include in image.

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ endif
 	docker run --rm -v $(CURDIR)/dist/bin:/go/bin:rw $(CALICO_BUILD) /bin/sh -c "\
 	  echo; echo calico-node-$(ARCH) -v;	 /go/bin/calico-node-$(ARCH) -v; \
 	"
-	docker build --pull -t $(BUILD_IMAGE):latest-$(ARCH) . --build-arg BIRD_IMAGE=$(BIRD_IMAGE) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./Dockerfile.$(ARCH)
+	docker build -t $(BUILD_IMAGE):latest-$(ARCH) . --build-arg BIRD_IMAGE=$(BIRD_IMAGE) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./Dockerfile.$(ARCH)
 	touch $@
 
 # download BIRD source to include in image.

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -535,12 +535,7 @@ func configureIPsAndSubnets(node *api.Node) (bool, error) {
 		validateIP(node.Spec.BGP.IPv4Address)
 	} else if ipv4Env != "none" {
 		if ipv4Env != "" {
-			// Attempt to get the local cidr of ipv4Env
-			ipv4CidrOrIP, err := getLocalCidr(ipv4Env, 4)
-			if err != nil {
-				log.Warnf("Attempt to get the local cidr of %v failed, %s",ipv4Env,err)
-			}
-			node.Spec.BGP.IPv4Address = parseIPEnvironment("IP", ipv4CidrOrIP, 4)
+			node.Spec.BGP.IPv4Address = parseIPEnvironment("IP", ipv4Env, 4)
 		}
 		validateIP(node.Spec.BGP.IPv4Address)
 	}
@@ -1369,55 +1364,4 @@ func extractKubeadmCIDRs(kubeadmConfig *v1.ConfigMap) (string, string, error) {
 	}
 
 	return v4, v6, err
-}
-
-// Check if the string is cidr
-// Since: internal/bytealg/indexbyte_generic.go
-func indexByteString(s string, c byte) int {
-	for i := 0; i < len(s); i++ {
-		if s[i] == c {
-			return i
-		}
-	}
-	return -1
-}
-
-// return the cidr of the dest on local
-func getLocalCidr(ip string, version int) (string, error) {
-	i := indexByteString(ip, '/')
-	if i >= 0 {
-		log.Infof("%s is already cidr", ip)
-		return ip, nil
-	}
-	log.Infof("Auto-detecting IPv%d CIDR of %s", version, ip)
-
-	// Get a full list of interface and IPs and find the CIDR matching the
-	// found IP.
-	ifaces, err := autodetection.GetInterfaces(nil, nil, version)
-	if err != nil {
-		return ip, err
-	}
-	for _, iface := range ifaces {
-		log.WithField("Name", iface.Name).Info("Checking interface CIDRs")
-		for _, cidr := range iface.Cidrs {
-			log.WithField("CIDR", cidr.String()).Info("Checking CIDR")
-			var destCidr net.IP
-			if version == 4 {
-				destCidr = net.ParseIP(ip).To4()
-			} else {
-				destCidr = net.ParseIP(ip).To16()
-			}
-			if destCidr == nil {
-				return ip, fmt.Errorf("%s is unreasonable not a reasonable ip str", ip)
-			}
-			if cidr.IP.Equal(destCidr) {
-				log.WithField("CIDR", cidr.String()).Info("Found local CIDR ")
-				return cidr.String(), nil
-			}
-		}
-	}
-
-	// Even if no cidr is found, it doesn't think it needs to throw an exception
-	log.Warnf("Unable to confirm IPv%d CIDR of %s", version, ip)
-	return ip, nil
 }

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -1109,5 +1110,38 @@ var _ = Describe("UTs for monitor-addresses option", func() {
 	It("poll-interval handles valid values", func() {
 		os.Setenv("AUTODETECT_POLL_INTERVAL", "30m")
 		Expect(getMonitorPollInterval()).To(Equal(30 * time.Minute))
+	})
+})
+
+var _ = Describe("UTs for env IP", func() {
+	Context("env IP is defined", func() {
+		It("get the local cidr", func() {
+
+			cmd := exec.Command("ip", "addr", "add", "1.2.3.4/24", "dev", "lo")
+			if err := cmd.Run(); err != nil {
+				Skip("ip addr add failed:" + err.Error())
+			}
+
+			ipv4Env := "1.2.3.4"
+			ipv4CidrOrIP, _ := getLocalCidr(ipv4Env, 4)
+			Expect(ipv4CidrOrIP).To(Equal("1.2.3.4/24"))
+
+			cmd = exec.Command("ip", "addr", "del", "1.2.3.4/24", "dev", "lo")
+			if err := cmd.Run(); err != nil {
+				Fail("ip addr del failed:" + err.Error())
+			}
+		})
+
+		It("get original cidr", func() {
+			ipv4Env := "4.3.2.1/24"
+			ipv4CidrOrIP, _ := getLocalCidr(ipv4Env, 4)
+			Expect(ipv4CidrOrIP).To(Equal("4.3.2.1/24"))
+		})
+
+		It("get original ip", func() {
+			ipv4Env := "4.3.2.1"
+			ipv4CidrOrIP, _ := getLocalCidr(ipv4Env, 4)
+			Expect(ipv4CidrOrIP).To(Equal("4.3.2.1"))
+		})
 	})
 })

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -1110,38 +1109,5 @@ var _ = Describe("UTs for monitor-addresses option", func() {
 	It("poll-interval handles valid values", func() {
 		os.Setenv("AUTODETECT_POLL_INTERVAL", "30m")
 		Expect(getMonitorPollInterval()).To(Equal(30 * time.Minute))
-	})
-})
-
-var _ = Describe("UTs for env IP", func() {
-	Context("env IP is defined", func() {
-		It("get the local cidr", func() {
-
-			cmd := exec.Command("ip", "addr", "add", "1.2.3.4/24", "dev", "lo")
-			if err := cmd.Run(); err != nil {
-				Skip("ip addr add failed:" + err.Error())
-			}
-
-			ipv4Env := "1.2.3.4"
-			ipv4CidrOrIP, _ := getLocalCidr(ipv4Env, 4)
-			Expect(ipv4CidrOrIP).To(Equal("1.2.3.4/24"))
-
-			cmd = exec.Command("ip", "addr", "del", "1.2.3.4/24", "dev", "lo")
-			if err := cmd.Run(); err != nil {
-				Fail("ip addr del failed:" + err.Error())
-			}
-		})
-
-		It("get original cidr", func() {
-			ipv4Env := "4.3.2.1/24"
-			ipv4CidrOrIP, _ := getLocalCidr(ipv4Env, 4)
-			Expect(ipv4CidrOrIP).To(Equal("4.3.2.1/24"))
-		})
-
-		It("get original ip", func() {
-			ipv4Env := "4.3.2.1"
-			ipv4CidrOrIP, _ := getLocalCidr(ipv4Env, 4)
-			Expect(ipv4CidrOrIP).To(Equal("4.3.2.1"))
-		})
 	})
 })


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes #563
When calico is used as a network plugin for kubernets, for convenience, only calico-cni.yml is used to configure the environment variables of calico-node.

```
- name: IP
  valueFrom:
    fieldRef:
      fieldPath: status.hostIP
```
At this time, it is hoped that calico-node can automatically discover the local cidr, so as to avoid using Block address and use IPIP successfully.
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
