### PR TITLE
downgrade ip autodetection logs to debug to prevent log spam

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -621,13 +621,13 @@ func validateIP(ipn string) {
 		terminate()
 	}
 	if len(ifaces) == 0 {
-		log.Info("No interfaces found for validating IP configuration")
+		log.Debug("No interfaces found for validating IP configuration")
 	}
 
 	for _, i := range ifaces {
 		for _, c := range i.Cidrs {
 			if ipAddr.Equal(c.IP) {
-				log.Infof("IPv%d address %s discovered on interface %s", ipAddr.Version(), ipAddr.String(), i.Name)
+				log.Debugf("IPv%d address %s discovered on interface %s", ipAddr.Version(), ipAddr.String(), i.Name)
 				return
 			}
 		}


### PR DESCRIPTION
## Description

Any info log messages printed during the ip monitor polling loop come out a bity spammy as they are executed every minute (by default). This PR downgrades a few log messages to info to prevent this spam.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```