### PR TITLE
Automatic restore aws metadata server route

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,7 +52,6 @@ blocks:
       - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make image-all cd CONFIRM=true; fi
 
-# build windows archive
 - name: "build windows archive"
   dependencies: []
   task:

--- a/windows-packaging/CalicoWindows/node/node-service.ps1
+++ b/windows-packaging/CalicoWindows/node/node-service.ps1
@@ -31,6 +31,8 @@ if ($env:CNI_IPAM_TYPE -EQ "host-local") {
     $env:USE_POD_CIDR = "false"
 }
 
+$platform = Get-PlatformType
+
 if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp" -OR $env:CALICO_NETWORKING_BACKEND -EQ "vxlan")
 {
     Write-Host "Calico $env:CALICO_NETWORKING_BACKEND networking enabled."
@@ -104,6 +106,10 @@ if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp" -OR $env:CALICO_NETWORKING_
     $mgmtIP = Wait-ForManagementIP "External"
     Write-Host "Management IP detected on vSwitch: $mgmtIP."
     Start-Sleep 10
+
+    if ($platform -EQ "ec2") {
+        Set-AwsMetaDataServerRoute -mgmtIP $mgmtIP
+    }
 
     if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp") {
         Write-Host "Restarting BGP service to pick up any interface renumbering..."


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR to is fix `The route to the metadata server is lost when the vSwitch is created`.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
