### PR TITLE
mirror.centos.org -> vault.centos.org

### DIFF
--- a/centos.repo
+++ b/centos.repo
@@ -1,14 +1,13 @@
 [centos-8-base-os]
 name = CentOS - BaseOS
-baseurl = http://mirror.centos.org/centos/8.1.1911/BaseOS/x86_64/os
+baseurl = http://vault.centos.org/8.1.1911/BaseOS/x86_64/os
 enabled = 1
 gpgkey = https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 gpgcheck = 1
 
 [centos-8-appstream]
 name = CentOS - AppStream
-baseurl = http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os
+baseurl = http://vault.centos.org/8.1.1911/AppStream/x86_64/os
 enabled = 1
 gpgkey = https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 gpgcheck = 1
-


### PR DESCRIPTION
http://mirror.centos.org/centos/8.1.1911/readme now says:

    This directory (and version of CentOS) is deprecated.  For normal users,
    you should use /8/ and not /8.1.1911/ in your path. Please see this FAQ
    concerning the CentOS release scheme:

    https://wiki.centos.org/FAQ/General

    If you know what you are doing, and absolutely want to remain at the 8.1.1911
    level, go to http://vault.centos.org/ for packages.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
