### PR TITLE
Bump up Alpine version to support NFT

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -19,7 +19,7 @@ FROM ${BIRD_IMAGE} as bird
 
 FROM calico/bpftool:v5.0-arm64 as bpftool
 
-FROM arm64v8/alpine:3.8 as base
+FROM arm64v8/alpine:3.12 as base
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 ARG ARCH=arm64


### PR DESCRIPTION
Alpine version 3.8 does not support iptables-legacy and iptables-nft
breaking autodetection. This change bumps the version of Alpine to
one that does.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
