### PR TITLE
Autodetect IP option to extract IP from kubernetes node status

### DIFF
--- a/pkg/startup/autodetection/autodetection_suite_test.go
+++ b/pkg/startup/autodetection/autodetection_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 

--- a/pkg/startup/autodetection/filtered.go
+++ b/pkg/startup/autodetection/filtered.go
@@ -18,8 +18,9 @@ import (
 	"fmt"
 	gnet "net"
 
-	"github.com/projectcalico/libcalico-go/lib/net"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
 // FilteredEnumeration performs basic IP and IPNetwork discovery by enumerating

--- a/pkg/startup/autodetection/interfaces.go
+++ b/pkg/startup/autodetection/interfaces.go
@@ -18,8 +18,9 @@ import (
 	"regexp"
 	"strings"
 
-	cnet "github.com/projectcalico/libcalico-go/lib/net"
 	log "github.com/sirupsen/logrus"
+
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
 // Interface contains details about an interface on the host.

--- a/pkg/startup/autodetection/k8snode.go
+++ b/pkg/startup/autodetection/k8snode.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016,2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package autodetection
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+)
+
+// GetKubernetesInternalIPAddresses returns the internal IP addresses configured on the node status.
+func GetKubernetesInternalIPAddresses(version int, node *v1.Node) ([]cnet.IPNet, error) {
+	var cidrs []cnet.IPNet
+	var err error
+	for _, nodeAddr := range node.Status.Addresses {
+		if nodeAddr.Type == v1.NodeInternalIP {
+			if _, cidr, cerr := cnet.ParseCIDROrIP(nodeAddr.Address); cerr != nil {
+				err = cerr
+			} else if cidr.Version() == version {
+				cidrs = append(cidrs, *cidr)
+			}
+		}
+	}
+
+	return cidrs, err
+}

--- a/pkg/startup/autodetection/k8snode_test.go
+++ b/pkg/startup/autodetection/k8snode_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package autodetection_test
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/projectcalico/node/pkg/startup/autodetection"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Kubernetes nodes tests", func() {
+
+	It("should extract IP addresses", func() {
+		node := &v1.Node{
+			Status: v1.NodeStatus{
+				Addresses: []v1.NodeAddress{{
+					Type:    v1.NodeInternalDNS,
+					Address: "hello",
+				}, {
+					Type:    v1.NodeExternalIP,
+					Address: "1.2.3.4",
+				}, {
+					Type:    v1.NodeInternalIP,
+					Address: "1.2.3.40",
+				}, {
+					Type:    v1.NodeExternalIP,
+					Address: "1.2.30.4",
+				}, {
+					Type:    v1.NodeInternalIP,
+					Address: "3333::1122",
+				}, {
+					Type:    v1.NodeInternalIP,
+					Address: "1.20.3.4",
+				}},
+			},
+		}
+
+		By("Checking IPv4 addresses extracted")
+		cidrs, err := autodetection.GetKubernetesInternalIPAddresses(4, node)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cidrs).To(HaveLen(2))
+		Expect(cidrs[0].String()).To(Equal("1.2.3.40"))
+		Expect(cidrs[1].String()).To(Equal("1.20.3.4"))
+
+		By("Checking IPv6 address extracted")
+		cidrs, err = autodetection.GetKubernetesInternalIPAddresses(6, node)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cidrs).To(HaveLen(1))
+		Expect(cidrs[0].String()).To(Equal("3333::1122"))
+	})
+
+	It("should handle a bad IP value", func() {
+		node := &v1.Node{
+			Status: v1.NodeStatus{
+				Addresses: []v1.NodeAddress{{
+					Type:    v1.NodeInternalIP,
+					Address: "hello",
+				}},
+			},
+		}
+
+		By("Checking IPv4 address not extracted and error raised")
+		cidrs, err := autodetection.GetKubernetesInternalIPAddresses(4, node)
+		Expect(err).To(HaveOccurred())
+		Expect(cidrs).To(BeNil())
+	})
+
+	It("should handle a bad IP value and a good one", func() {
+		node := &v1.Node{
+			Status: v1.NodeStatus{
+				Addresses: []v1.NodeAddress{{
+					Type:    v1.NodeInternalIP,
+					Address: "hello",
+				}, {
+					Type:    v1.NodeInternalIP,
+					Address: "1.2.3.4",
+				}},
+			},
+		}
+
+		By("Checking IPv4 addresses extracted and error raised")
+		cidrs, err := autodetection.GetKubernetesInternalIPAddresses(4, node)
+		Expect(err).To(HaveOccurred())
+		Expect(cidrs).To(HaveLen(1))
+		Expect(cidrs[0].String()).To(Equal("1.2.3.4"))
+	})
+
+	It("should handle an empty status", func() {
+		node := &v1.Node{}
+
+		By("Checking IPv4 addresses not extracted")
+		cidrs, err := autodetection.GetKubernetesInternalIPAddresses(4, node)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cidrs).To(BeNil())
+	})
+})

--- a/pkg/startup/autodetection/reachaddr.go
+++ b/pkg/startup/autodetection/reachaddr.go
@@ -17,8 +17,9 @@ import (
 	"fmt"
 	gonet "net"
 
-	"github.com/projectcalico/libcalico-go/lib/net"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/net"
 )
 
 // ReachDestination auto-detects the interface Network by setting up a UDP

--- a/pkg/startup/startup_suite_test.go
+++ b/pkg/startup/startup_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -97,7 +97,7 @@ var _ = DescribeTable("Node IP detection failure cases",
 		if rrCId != "" {
 			node.Spec.BGP = &api.NodeBGPSpec{RouteReflectorClusterID: rrCId}
 		}
-		_ = configureAndCheckIPAddressSubnets(context.Background(), c, &node)
+		_ = configureAndCheckIPAddressSubnets(context.Background(), c, &node, nil)
 		Expect(my_ec).To(Equal(expectedExitCode))
 		if rrCId != "" {
 			Expect(node.Spec.BGP).NotTo(BeNil())
@@ -875,7 +875,7 @@ var _ = Describe("UT for Node IP assignment and conflict checking.", func() {
 				os.Setenv(item.key, item.value)
 			}
 
-			check, err := configureIPsAndSubnets(node)
+			check, err := configureIPsAndSubnets(node, nil)
 
 			Expect(check).To(Equal(expected))
 			Expect(err).NotTo(HaveOccurred())
@@ -1117,7 +1117,7 @@ var _ = Describe("UT for IP and IP6", func() {
 	DescribeTable("env IP is defined", func(ipv4Env string, version int, exceptValue string) {
 		ipv4MockInterfaces := func([]string, []string, int) ([]autodetection.Interface, error) {
 			return []autodetection.Interface{
-				{Name: "eth1", Cidrs: []net.IPNet{net.MustParseCIDR("1.2.3.4/24")},}}, nil
+				{Name: "eth1", Cidrs: []net.IPNet{net.MustParseCIDR("1.2.3.4/24")}}}, nil
 		}
 		ipv4CIDROrIP, _ := getLocalCIDR(ipv4Env, version, ipv4MockInterfaces)
 		Expect(ipv4CIDROrIP).To(Equal(exceptValue))
@@ -1125,13 +1125,12 @@ var _ = Describe("UT for IP and IP6", func() {
 		Entry("get the local cidr", "1.2.3.4", 4, "1.2.3.4/24"),
 		Entry("get the original cidr", "4.3.2.1/25", 4, "4.3.2.1/25"),
 		Entry("get the original ip(v4)", "1.2.3.5", 4, "1.2.3.5"),
-
 	)
 
 	var _ = DescribeTable("env IP6 is defined", func(ipv6Env string, version int, exceptValue string) {
 		ipv6MockInterfaces := func([]string, []string, int) ([]autodetection.Interface, error) {
 			return []autodetection.Interface{
-				{Name: "eth1", Cidrs: []net.IPNet{net.MustParseCIDR("1:2:3:4::5/120")},}}, nil
+				{Name: "eth1", Cidrs: []net.IPNet{net.MustParseCIDR("1:2:3:4::5/120")}}}, nil
 		}
 		ipv4CIDROrIP, _ := getLocalCIDR(ipv6Env, version, ipv6MockInterfaces)
 		Expect(ipv4CIDROrIP).To(Equal(exceptValue))


### PR DESCRIPTION
## Description
Add new node auto detection method using kubernetes node status.

Not sure this really makes sense.... perhaps for k8s backend we should just always attempt to get the ip address from the k8s node status.  Not sure... but then also have to handle etcd backend, so maybe this is ok.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
