### PR TITLE
Add log configuration to monitor-addresses command

### DIFF
--- a/cmd/calico-node/main.go
+++ b/cmd/calico-node/main.go
@@ -113,6 +113,7 @@ func main() {
 		startup.Run()
 	} else if *monitorAddrs {
 		logrus.SetFormatter(&logutils.Formatter{Component: "monitor-addresses"})
+		startup.ConfigureLogging()
 		startup.MonitorIPAddressSubnets()
 	} else if *runConfd {
 		logrus.SetFormatter(&logutils.Formatter{Component: "confd"})

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -96,7 +96,7 @@ var (
 // -  Creating default IP Pools for quick-start use
 func Run() {
 	// Check $CALICO_STARTUP_LOGLEVEL to capture early log statements
-	configureLogging()
+	ConfigureLogging()
 
 	// Determine the name for this node.
 	nodeName := determineNodeName()
@@ -365,7 +365,7 @@ func clearNodeIPs(ctx context.Context, client client.Interface, node *api.Node, 
 	}
 }
 
-func configureLogging() {
+func ConfigureLogging() {
 	// Default to info level logging
 	logLevel := log.InfoLevel
 


### PR DESCRIPTION
## Description

This PR includes a suggested change which would make monitor-addresses command also respect the CALICO_STARTUP_LOGLEVEL environment variable. 

Without this, unneccessary information log events are sent every minute per node.

As far as I understand, this change should not affect any other components.

## Todos
- [ ] Tests - help needed for testing, as I have problems building and testing the change.
- [X] Documentation - not needed, as this makes monitor-addresses command also adhere to [docs](https://docs.projectcalico.org/reference/node/configuration#configuring-logging) 
- [X] Release note - I assume not needed

```release-note
Address monitor now respects the CALICO_STARTUP_LOGLEVEL environment variable
```