### PR TITLE
Bump ubi:8.1 to 8.3 to get latest security fixes

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -94,7 +94,7 @@ RUN wget -P /tmp http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz && \
     cd /tmp/admin/runit-${RUNIT_VER}/ && \
     package/install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1 as ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 as ubi
 ARG ARCH
 ARG GIT_VERSION
 ARG IPTABLES_VER


### PR DESCRIPTION
## Description
Bug fix: Redhat strongly recommends to upgrade to latest 8.3 ubi image to get the several (52 vulnerabilities for 25 packages) here: https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?tag=8.1&push_date=1586271046000&container-tabs=security

PS: this is my first contribution to calico, so happy to correct anything or follow any steps I may have missed

```release-note
Bump UBI from 8.1 to 8.3
```