### PR TITLE
Fix winrm hang on Wait-ForCalicoInit

### DIFF
--- a/windows-packaging/CalicoWindows/install-calico.ps1
+++ b/windows-packaging/CalicoWindows/install-calico.ps1
@@ -56,8 +56,6 @@ else
 Write-Host "Starting Calico..."
 Write-Host "This may take several seconds if the vSwitch needs to be created."
 
-Start-Service CalicoNode
-Wait-ForCalicoInit
 Start-Service CalicoFelix
 
 if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp")


### PR DESCRIPTION
CalicoFelix service dependso n CalicoNode service, therefore we are
safe to remove Start-Service CalicoNode and Wait-ForCalicoInit
Plus,
https://github.com/projectcalico/node/blob/master/windows-packaging/CalicoWindows/felix/felix-service.ps1
waits on CalicoInit as well.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- bug fix
- Installing calico through 'vagrant winrm' and the vagrant shell provisioner hangs waiting for CalicoNode to start.  The wait is not needed as it's also called through the CalicoFelix wrapper script and CalicoFelix has a service dependency on CalicoNode
- Manually tested with https://github.com/cdd-aix/microk8s-kubernetes/tree/develop ... install-calico does not hang
- node/windows-packaging component is modified
- No issues opened before submitting this PR.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
