### PR TITLE
Bump alpine version to 3.13

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -19,7 +19,7 @@ FROM ${BIRD_IMAGE} as bird
 
 FROM calico/bpftool:v5.0-arm64 as bpftool
 
-FROM arm64v8/alpine:3.12 as base
+FROM arm64v8/alpine:3.13 as base
 MAINTAINER Casey Davenport <casey@tigera.io>
 
 ARG ARCH=arm64


### PR DESCRIPTION
## Description

**DISCLAIMER**: First of all I'm not entirely sure why this is happening but this solved my problems on my Raspberry PI Cluster which I use for R&D.

### System

* I'm using the lasted build for Raspberry PI 64 bits [raspios_lite_arm64-2021-04-09](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-04-09/)
* Calico version 3.19
* Kubernetes 1.21

### Error

```
iptables-nft-restore v1.8.4 (nf_tables): unknown arguments found on commandline
Error occurred at line: 3
```

### Reproduce error

1. Lunch container with calico image 3.19
```
docker run --rm -it --privileged --network host calico/node:v3.19.0 /bin/sh
```

2.  Try to load dummy iptables snapshot:
```
cat | iptables-nft-restore --wait --wait-interval --noflush --verbose <<EOF
*nat
:cali-fip-snat - -
COMMIT
EOF
```

----

### Testing new alpine version

1. Built new docker image on top of **calico/node:v3.19.0**:

```Dockerfile
FROM calico/node:v3.19.0

RUN sed -i -e 's/v3.12/v3.13/g' /etc/apk/repositories
RUN apk upgrade
```

2. And edited the manifest to use: [docker.io/patrickfmarques/calico-node:v3.19.0](https://hub.docker.com/layers/patrickfmarques/calico-node/v3.19.0/images/sha256-7619c5dbd75b69c3b43347ee48c08745296bd44224e732048f25740e7b866132?context=repo&tab=layers)

#### Alpine upgrade logs

```
fetch http://dl-cdn.alpinelinux.org/alpine/v3.13/main/aarch64/APKINDEX.tar.gz        
fetch http://dl-cdn.alpinelinux.org/alpine/v3.13/community/aarch64/APKINDEX.tar.gz
Upgrading critical system libraries and apk-tools:                                                                     
(1/2) Upgrading musl (1.1.24-r10 -> 1.2.2-r0)                                                                          
(2/2) Upgrading apk-tools (2.10.6-r0 -> 2.12.5-r0)                                                                     
Executing busybox-1.31.1-r20.trigger                       
Continuing the upgrade transaction with new apk-tools:                                                                 
(1/22) Upgrading busybox (1.31.1-r20 -> 1.32.1-r6)                                                                     
Executing busybox-1.32.1-r6.post-upgrade                                                                               
(2/22) Upgrading alpine-baselayout (3.2.0-r7 -> 3.2.0-r8)                                                              
Executing alpine-baselayout-3.2.0-r8.pre-upgrade                                                                       
Executing alpine-baselayout-3.2.0-r8.post-upgrade                                                                      
(3/22) Upgrading ca-certificates-bundle (20191127-r4 -> 20191127-r5)                                                   
(4/22) Upgrading ssl_client (1.31.1-r20 -> 1.32.1-r6)                                                                  
(5/22) Upgrading ca-certificates (20191127-r4 -> 20191127-r5)                                                          
(6/22) Upgrading libmnl (1.0.4-r0 -> 1.0.4-r1)                                                                         
(7/22) Upgrading libnetfilter_cthelper (1.0.0-r0 -> 1.0.0-r1)                                                          
(8/22) Upgrading libnetfilter_cttimeout (1.0.0-r0 -> 1.0.0-r1)                                                         
(9/22) Upgrading libnetfilter_queue (1.0.3-r0 -> 1.0.5-r0)                                                             
(10/22) Upgrading libnftnl-libs (1.1.6-r0 -> 1.1.8-r0)                                                                 
(11/22) Upgrading iptables (1.8.4-r2 -> 1.8.6-r0)                                                                      
(12/22) Upgrading ip6tables (1.8.4-r2 -> 1.8.6-r0)                                                                     
(13/22) Upgrading iproute2 (5.6.0-r0 -> 5.10.0-r1)                                                                     
(14/22) Upgrading libelf (0.179-r0 -> 0.182-r0)                                                                        
(15/22) Installing iproute2-tc (5.10.0-r1)                                                                             
(16/22) Installing iproute2-minimal (5.10.0-r1)                                                                        
(17/22) Installing iproute2-ss (5.10.0-r1)                                                                             
(18/22) Upgrading ipset (7.6-r0 -> 7.10-r0)                                                                            
(19/22) Upgrading libcap (2.27-r0 -> 2.46-r0)                                                                          
(20/22) Upgrading iputils (20190709-r0 -> 20190709-r1)                                                                 
(21/22) Upgrading scanelf (1.2.6-r0 -> 1.2.8-r0)                                                                       
(22/22) Upgrading musl-utils (1.1.24-r10 -> 1.2.2-r0)                                                                  
Executing busybox-1.32.1-r6.trigger                                                                                    
Executing ca-certificates-20191127-r5.trigger                                                                          
OK: 13 MiB in 37 packages                                                                                              
```

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
