### PR TITLE
windows: set kube-proxy IPv6DualStack=false for VXLAN

### DIFF
--- a/windows-packaging/CalicoWindows/kubernetes/kube-proxy-service.ps1
+++ b/windows-packaging/CalicoWindows/kubernetes/kube-proxy-service.ps1
@@ -77,6 +77,10 @@ if ($network.Type -EQ "Overlay") {
     $sourceVip = (Get-HnsEndpoint | ? Name -EQ "Calico_ep").IpAddress
     $argList += "--source-vip=$sourceVip"
     $extraFeatures += "WinOverlay=true"
+
+    # VXLAN on Windows doesn't support dualstack so disable explicitly. From k8s
+    # 1.21 onwards IPv6DualStack defaults to true
+    $extraFeatures += "IPv6DualStack=false"
 }
 
 if ($extraFeatures.Length -GT 0) {


### PR DESCRIPTION
## Description

Overlay on Windows doesn't support dualstack so disable explicitly. From k8s 1.21 onwards IPv6DualStack defaults to true
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
