### PR TITLE
windows: create VXLAN tunnel address in node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
 	github.com/projectcalico/api v0.0.0-20210706154750-8686d6f77130
-	github.com/projectcalico/cni-plugin v1.11.1-0.20210708232629-a0af94f175cc
+	github.com/projectcalico/cni-plugin v1.11.1-0.20210713192619-3dcf4cdb4636
 	github.com/projectcalico/felix v0.0.0-20210705102911-d04ee2c303fd
-	github.com/projectcalico/libcalico-go v1.7.2-0.20210707205620-dad54d60f894
+	github.com/projectcalico/libcalico-go v1.7.2-0.20210712155928-719c24d19752
 	github.com/projectcalico/typha v0.7.3-0.20210706170700-733c771df430
 	github.com/sirupsen/logrus v1.7.0
 	github.com/vishvananda/netlink v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -619,6 +619,7 @@ github.com/projectcalico/api v0.0.0-20210706154750-8686d6f77130 h1:XbWIFiBucZRo9
 github.com/projectcalico/api v0.0.0-20210706154750-8686d6f77130/go.mod h1:8raLpE2oURN0I33JpEniA3LmAs5uPZ1kGnW/YunYEB0=
 github.com/projectcalico/cni-plugin v1.11.1-0.20210708232629-a0af94f175cc h1:CNzC9cS5sN0UQG6KRrJsfhCtCLeOrVeQ+ahEV2WQRm0=
 github.com/projectcalico/cni-plugin v1.11.1-0.20210708232629-a0af94f175cc/go.mod h1:IOGK5nHF172Xtb6VyrVq6oLhDrf5dvFHPj4yEucKNQk=
+github.com/projectcalico/cni-plugin v1.11.1-0.20210713192619-3dcf4cdb4636 h1:eMYjOQynNIm4O62eBC3/TJM18d5PMCUnbkl5+Qvm9Vg=
 github.com/projectcalico/cni-plugin v1.11.1-0.20210713192619-3dcf4cdb4636/go.mod h1:hM3Y9wpr/wZt++7CZ+u94bPNwYVM8f9SnezFW2hlu1o=
 github.com/projectcalico/confd v1.0.1-0.20210706171510-82673c0a6e04 h1:+ef8xe5gQmdHA/RdWxG8wgSq3Vzfqu4j2D000VFp55c=
 github.com/projectcalico/confd v1.0.1-0.20210706171510-82673c0a6e04/go.mod h1:0scwt+qHMlcD2CVoFyfOK8ALWFh6BXG6fIsmDt7IAmU=

--- a/go.sum
+++ b/go.sum
@@ -619,6 +619,7 @@ github.com/projectcalico/api v0.0.0-20210706154750-8686d6f77130 h1:XbWIFiBucZRo9
 github.com/projectcalico/api v0.0.0-20210706154750-8686d6f77130/go.mod h1:8raLpE2oURN0I33JpEniA3LmAs5uPZ1kGnW/YunYEB0=
 github.com/projectcalico/cni-plugin v1.11.1-0.20210708232629-a0af94f175cc h1:CNzC9cS5sN0UQG6KRrJsfhCtCLeOrVeQ+ahEV2WQRm0=
 github.com/projectcalico/cni-plugin v1.11.1-0.20210708232629-a0af94f175cc/go.mod h1:IOGK5nHF172Xtb6VyrVq6oLhDrf5dvFHPj4yEucKNQk=
+github.com/projectcalico/cni-plugin v1.11.1-0.20210713192619-3dcf4cdb4636/go.mod h1:hM3Y9wpr/wZt++7CZ+u94bPNwYVM8f9SnezFW2hlu1o=
 github.com/projectcalico/confd v1.0.1-0.20210706171510-82673c0a6e04 h1:+ef8xe5gQmdHA/RdWxG8wgSq3Vzfqu4j2D000VFp55c=
 github.com/projectcalico/confd v1.0.1-0.20210706171510-82673c0a6e04/go.mod h1:0scwt+qHMlcD2CVoFyfOK8ALWFh6BXG6fIsmDt7IAmU=
 github.com/projectcalico/felix v0.0.0-20210705102911-d04ee2c303fd h1:eCqs6cgQMGr2tJImL7qcrR2zcSKrA3dZ9Y9f8Bod47E=
@@ -633,6 +634,8 @@ github.com/projectcalico/libcalico-go v1.7.2-0.20210626085404-b893bd8ebf1d/go.mo
 github.com/projectcalico/libcalico-go v1.7.2-0.20210706164741-883bc4215d31/go.mod h1:MAPmOmAdMf/8okDUVPEnVAhUvXdZZqbksGedHkIhv+Y=
 github.com/projectcalico/libcalico-go v1.7.2-0.20210707205620-dad54d60f894 h1:vpPUfAzYD5htZyY+9g3lQwt+t9as/sBT/agn7wpEttE=
 github.com/projectcalico/libcalico-go v1.7.2-0.20210707205620-dad54d60f894/go.mod h1:MAPmOmAdMf/8okDUVPEnVAhUvXdZZqbksGedHkIhv+Y=
+github.com/projectcalico/libcalico-go v1.7.2-0.20210712155928-719c24d19752 h1:EqRBp+MbEOKEVRZ6UNftf9n1Qy+mEHd036kOwa6l06o=
+github.com/projectcalico/libcalico-go v1.7.2-0.20210712155928-719c24d19752/go.mod h1:MAPmOmAdMf/8okDUVPEnVAhUvXdZZqbksGedHkIhv+Y=
 github.com/projectcalico/logrus v1.0.4-calico h1:bHJ2KLGTFzoWpRISe13CO7HVxxrKunDjyUz/wFiBY8c=
 github.com/projectcalico/logrus v1.0.4-calico/go.mod h1:DfgrchabbtEO9wjOz5lVae+XRvjFKKWEA9GTMme6A8g=
 github.com/projectcalico/pod2daemon v0.0.0-20210618180306-4763e2755cba h1:kTXgYOTM7CQolOr/2j8O1XdfMfD+VJDA/7EIgCIFKks=

--- a/pkg/lifecycle/startup/startup_windows.go
+++ b/pkg/lifecycle/startup/startup_windows.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -89,7 +90,17 @@ func ensureNetworkForOS(ctx context.Context, c client.Interface, nodeName string
 				return err
 			}
 			_, err = windows.SetupVxlanNetwork(networkName, subnet, uint64(vni), logrus.WithField("subnet", subnet.String()))
+			for attempts := 3; attempts > 0; attempts-- {
+				err = windows.EnsureVXLANTunnelAddr(ctx, c, nodeName, subnet, networkName)
+				if err != nil {
+					logrus.WithError(err).Warn("Failed to set node's VXLAN tunnel IP, node may not receive traffic.  May retry...")
+					time.Sleep(1 * time.Second)
+					continue
+				}
+				break
+			}
 			if err != nil {
+				logrus.WithError(err).Error("Failed to set node's VXLAN tunnel IP after retries, node may not receive traffic.")
 				return err
 			}
 		} else {

--- a/pkg/lifecycle/startup/startup_windows.go
+++ b/pkg/lifecycle/startup/startup_windows.go
@@ -90,6 +90,9 @@ func ensureNetworkForOS(ctx context.Context, c client.Interface, nodeName string
 				return err
 			}
 			_, err = windows.SetupVxlanNetwork(networkName, subnet, uint64(vni), logrus.WithField("subnet", subnet.String()))
+			if err != nil {
+				return err
+			}
 			for attempts := 3; attempts > 0; attempts-- {
 				err = windows.EnsureVXLANTunnelAddr(ctx, c, nodeName, subnet, networkName)
 				if err != nil {


### PR DESCRIPTION
## Description

Previously this was done in cni-plugin when the first pod is set up. But since then we create the IPAM block in node so we can create the tunnel address along with the network. Setting up the VXLAN tunnel address when setting up the network enables other approaches to installing Calico for Windows (e.g. with wins).

See also: https://github.com/projectcalico/cni-plugin/pull/1104

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
windows: create VXLAN tunnel address in node - previously this was done in cni-plugin when the first pod is set up
```
