### PR TITLE
windows: replace WMI cmdlet usage with CIM

### DIFF
--- a/windows-packaging/CalicoWindows/libs/calico/calico.psm1
+++ b/windows-packaging/CalicoWindows/libs/calico/calico.psm1
@@ -304,7 +304,7 @@ function Wait-ForManagementIP($NetworkName)
 
 function Get-LastBootTime()
 {
-    $bootTime = (Get-WmiObject win32_operatingsystem | select @{LABEL='LastBootUpTime';EXPRESSION={$_.lastbootuptime}}).LastBootUpTime
+    $bootTime = (Get-CimInstance win32_operatingsystem | select @{LABEL='LastBootUpTime';EXPRESSION={$_.lastbootuptime}}).LastBootUpTime
     if (($bootTime -EQ $null) -OR ($bootTime.length -EQ 0))
     {
         throw "Failed to get last boot time"


### PR DESCRIPTION
## Description

WMI is deprecated and not available on Powershell 7 so replace its usage with CIM.

Addresses part of https://github.com/projectcalico/node/issues/1083
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
