### PR TITLE
Configurable VXLAN adapter

### DIFF
--- a/windows-packaging/CalicoWindows/config.ps1
+++ b/windows-packaging/CalicoWindows/config.ps1
@@ -59,7 +59,8 @@ $env:CNI_IPAM_TYPE = "calico-ipam"
 $env:VXLAN_VNI = "4096"
 # Prefix used when generating MAC addresses for virtual NICs.
 $env:VXLAN_MAC_PREFIX = "0E-2A"
-
+# Network Adapter used on VXLAN, leave blank for primary NIC. 
+$env:VXLAN_ADAPTER = ""
 
 ## Node configuration.
 

--- a/windows-packaging/CalicoWindows/node/node-service.ps1
+++ b/windows-packaging/CalicoWindows/node/node-service.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 Tigera, Inc. All rights reserved.
+# Copyright (c) 2018-2021 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ $Stored = Get-StoredLastBootTime
 Write-Host "StoredLastBootTime $Stored, CurrentLastBootTime $lastBootTime"
 
 $timeout = $env:STARTUP_VALID_IP_TIMEOUT
+$vxlanAdapter = $env:VXLAN_ADAPTER
 
 # Autoconfigure the IPAM block mode.
 if ($env:CNI_IPAM_TYPE -EQ "host-local") {
@@ -87,7 +88,7 @@ if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp" -OR $env:CALICO_NETWORKING_
         if ($env:CALICO_NETWORKING_BACKEND -EQ "vxlan") {
             # FIXME Firewall rule port?
             New-NetFirewallRule -Name OverlayTraffic4789UDP -Description "Overlay network traffic UDP" -Action Allow -LocalPort 4789 -Enabled True -DisplayName "Overlay Traffic 4789 UDP" -Protocol UDP -ErrorAction SilentlyContinue
-            $result = New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })  -Verbose
+            $result = New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; }) -AdapterName $vxlanAdapter -Verbose
         }
         else
         {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This PR enables the capability to configure the adapter name when creating a new HNS network, this is useful when multiple NIC exist in the host.

When the value is not set the primary NIC should be used.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Windows VXLAN network adapter can be configurable when multi interfaces exist.
```
