### PR TITLE
Allow longer for 'make cd', now that we build more architectures

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -105,7 +105,7 @@ blocks:
       jobs:
       - name: "make cd"
         execution_time_limit:
-          minutes: 30
+          minutes: 60
         commands:
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io


### PR DESCRIPTION
It's counter-productive if a CI run times out and fails in this step,
and then the whole CI run needs to be repeated.
