### PR TITLE
Add Windows docker image for calico node

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,6 @@
 # - CentOS repository file and our license
 !centos.repo
 !LICENSE
+!windows-packaging/CalicoWindows/libs
+!windows-packaging/CalicoWindows/node
+!windows-packaging/CalicoWindows/felix

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -1,0 +1,37 @@
+# Copyright (c) 2015-2019 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+ARG GIT_VERSION=unknown
+
+# Required labels for certification
+LABEL name="Calico node" \
+      vendor="Project Calico" \
+      version=$GIT_VERSION \
+      release="1" \
+      summary="Calico node handles networking and policy for Calico" \
+      description="Calico node handles networking and policy for Calico" \
+      maintainer="laurence@tigera.io"
+
+ADD LICENSE /licenses/
+
+ADD dist/bin/calico-node.exe /calico/calico-node.exe
+ADD windows-packaging/CalicoWindows/felix/felix-service.ps1 /calico/felix-service.ps1
+ADD windows-packaging/CalicoWindows/node/node-service.ps1 /calico/node-service.ps1
+Add windows-packaging/CalicoWindows/libs/calico/calico.psm1 /calico/libs/calico/calico.psm1
+Add windows-packaging/CalicoWindows/libs/hns/hns.psm1 /calico/libs/hns/hns.psm1
+
+ENV PATH=$PATH:/calico
+ENTRYPOINT ["powershell"]

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,14 @@ endif
 	docker build --pull -t $(NODE_IMAGE):latest-$(ARCH) $(TARGET_PLATFORM) . --build-arg BIRD_IMAGE=$(BIRD_IMAGE) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./Dockerfile.$(ARCH)
 	touch $@
 
+image-windows: clean-windows build 
+	docker buildx create --name img-builder --use --platform windows/amd64 
+	docker buildx build --platform windows/amd64 --output=type=registry --pull -t $(NODE_IMAGE):latest-$(ARCH)-windows --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile-windows .
+	docker buildx rm img-builder 
+
+clean-windows:
+	docker buildx rm img-builder || true
+
 # download BIRD source to include in image.
 $(BIRD_SOURCE): go.mod
 	mkdir -p filesystem/included-source/

--- a/windows-packaging/CalicoWindows/felix/felix-service.ps1
+++ b/windows-packaging/CalicoWindows/felix/felix-service.ps1
@@ -21,7 +21,7 @@ ipmo .\libs\calico\calico.psm1 -Force
 Wait-ForCalicoInit
 
 # Copy the nodename from the global setting.
-$env:FELIX_FELIXHOSTNAME = $env:NODENAME
+$env:FELIX_FELIXHOSTNAME = $(hostname).ToLower()
 
 # Disable OpenStack metadata server support, which is not available on Windows.
 $env:FELIX_METADATAADDR = "none"

--- a/windows-packaging/CalicoWindows/node/node-service.ps1
+++ b/windows-packaging/CalicoWindows/node/node-service.ps1
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 # This script is run from the main Calico folder.
-. .\config.ps1
-
 ipmo .\libs\calico\calico.psm1
 ipmo .\libs\hns\hns.psm1
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

I've trying out different cni's with Windows HostProcess containers and started to try out calico. Initially was working through powershell scripts but feel like using the same type of approach Linux uses is better.

This is a rough draft and can be combined with https://github.com/projectcalico/cni-plugin/pull/1148 to run calico in Hostprocess containers.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Adds support for Windows HostProcess containers
```
