### PR TITLE
Add 'make image-all' to CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,6 +28,16 @@ global_job_config:
       - git fetch --unshallow
 
 blocks:
+  - name: "Build Images"
+    dependencies: []
+    task:
+      jobs:
+        - name: "Build All Images"
+          execution_time_limit:
+            minutes: 120
+          commands:
+            - TEST_IMAGE_BUILD=true make image-all
+
   - name: "General Tests"
     dependencies: []
     task:
@@ -40,8 +50,18 @@ blocks:
             - make ut
             - make fv
 
-  - name: "System Tests"
+  - name: "Build amd64 Image"
     dependencies: []
+    task:
+      jobs:
+        - name: "Build amd64 Image"
+          execution_time_limit:
+            minutes: 120
+          commands:
+            - make image
+
+  - name: "System Tests"
+    dependencies: ["Build amd64 Image"]
     task:
       prologue:
         commands:

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,17 @@ image: remote-deps $(NODE_IMAGE)
 image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
 	$(MAKE) image ARCH=$*
+ifeq ($(TEST_IMAGE_BUILD),true)
+	# If testing image builds, clean sub-image afterwards to free disk space (for Semaphore CI)
+	$(MAKE) clean-sub-image-$*
+endif
+
+## Remove images for all supported ARCHes
+clean-image-all: $(addprefix clean-sub-image-,$(VALIDARCHES))
+## Remove sub-image from docker and delete $(NODE_CONTAINER_CREATED) file
+clean-sub-image-%:
+	rm -f .calico_node.created-$*
+	docker rmi $(NODE_IMAGE):latest-$* || true
 
 $(NODE_IMAGE): $(NODE_CONTAINER_CREATED)
 $(NODE_CONTAINER_CREATED): register ./Dockerfile.$(ARCH) $(NODE_CONTAINER_FILES) $(NODE_CONTAINER_BINARY) $(INCLUDED_SOURCE) remote-deps


### PR DESCRIPTION
Add 'make image-all' target to Makefile and corresponding job to semaphore.yml. Also add a job to build just the amd64 image (which is used by STs) as a prereq to run STs.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [X] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
