### PR TITLE
windows: fix install stuck at Wait-ForCalicoInit

### DIFF
--- a/windows-packaging/CalicoWindows/libs/calico/calico.psm1
+++ b/windows-packaging/CalicoWindows/libs/calico/calico.psm1
@@ -309,7 +309,10 @@ function Get-LastBootTime()
     {
         throw "Failed to get last boot time"
     }
-    return $bootTime
+ 
+    # This function is used in conjunction with Get-StoredLastBootTime, which
+    # returns a string, so convert the datetime value to a string using the "general" standard format.
+    return $bootTime.ToString("G")
 }
 
 $softwareRegistryKey = "HKLM:\Software\Tigera"


### PR DESCRIPTION
## Description

Get-LastBootTime was returning a datetime value which used to be a string.  In 13858b9ad0d178a249325634d4d30147074d222c we replaced Get-WmiObject with Get-CimInstance, which changed the return type.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
