### PR TITLE
Add handling for setting up hostpath directories for non-root use

### DIFF
--- a/cmd/calico-node/main.go
+++ b/cmd/calico-node/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/projectcalico/node/pkg/allocateip"
 	"github.com/projectcalico/node/pkg/cni"
 	"github.com/projectcalico/node/pkg/health"
+	"github.com/projectcalico/node/pkg/hostpathinit"
 	"github.com/projectcalico/node/pkg/lifecycle/shutdown"
 	"github.com/projectcalico/node/pkg/lifecycle/startup"
 )
@@ -70,6 +71,9 @@ var runConfd = flagSet.Bool("confd", false, "Run confd")
 var confdRunOnce = flagSet.Bool("confd-run-once", false, "Run confd in oneshot mode")
 var confdKeep = flagSet.Bool("confd-keep-stage-file", false, "Keep stage file when running confd")
 var confdConfDir = flagSet.String("confd-confdir", "/etc/calico/confd", "Confd configuration directory.")
+
+// non-root hostpath init flags
+var initHostpaths = flagSet.Bool("hostpath-init", false, "Initialize hostpaths for non-root access")
 
 func main() {
 	// Log to stdout.  this prevents our logs from being interpreted as errors by, for example,
@@ -151,6 +155,9 @@ func main() {
 	} else if *monitorToken {
 		logrus.SetFormatter(&logutils.Formatter{Component: "cni-config-monitor"})
 		cni.Run()
+	} else if *initHostpaths {
+		logrus.SetFormatter(&logutils.Formatter{Component: "hostpath-init"})
+		hostpathinit.Run()
 	} else {
 		fmt.Println("No valid options provided. Usage:")
 		flagSet.PrintDefaults()

--- a/pkg/hostpathinit/hostpath_init.go
+++ b/pkg/hostpathinit/hostpath_init.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package hostpathinit
+
+import (
+	"os"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Hostpath init should only need to be run when we are trying to
+// run calico-node as non-root. This creates the directories that
+// Calico needs on the host and changes their permissions so that
+// the Calico user can access them.
+func Run() {
+	uidStr := os.Getenv("NODE_USER_ID")
+	if uidStr == "" {
+		// Default the UID to 1000
+		uidStr = "1000"
+	}
+
+	uid, err := strconv.Atoi(uidStr)
+	if err != nil {
+		log.Panicf("Failed to parse value for UID %s", uidStr)
+	}
+
+	// Create the calico directory in /var/lib/
+	err = os.Mkdir("/var/lib/calico/", 0700)
+	if err != nil {
+		log.Panic("Unable to create directory /var/lib/calico/")
+	}
+
+	// Change ownership of /var/lib/calico/ to our non-root user
+	err = os.Chown("/var/lib/calico/", uid, 0)
+	if err != nil {
+		log.Panic("Unable to chown /var/lib/calico/")
+	}
+
+	// Create the calico directory in /var/run/
+	err = os.Mkdir("/var/run/calico/", 0700)
+	if err != nil {
+		log.Panic("Unable to create directory /var/run/calico/")
+	}
+
+	// Change ownership of /var/run/calico/ to our non-root user
+	err = os.Chown("/var/run/calico/", uid, 0)
+	if err != nil {
+		log.Panic("Unable to chown /var/run/calico/")
+	}
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Adds hostpath handling so that we will not need a separate image in order to do the hostpath permission setup for non-root calico-node usage. This should be used similar to the following manifest:
```
        - name: hostpath-init
          image: docker.io/calico/node:non-root
          command: ['sh', '-c', 'calico-node -hostpath-init']
          env:
            - name: NODE_USER_ID
              value: "1000"
          securityContext:
            runAsUser: 0
          volumeMounts:
          - mountPath: /var/run
            name: var-run
            readOnly: false
          - mountPath: /var/lib
            name: var-lib
            readOnly: false
```

These changes will be required for https://github.com/tigera/operator/pull/1544 to install it properly

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
