### PR TITLE
Fix image push hitting rate limits

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -127,17 +127,26 @@ blocks:
       secrets:
       - name: quay-robot-calico+semaphoreci
       - name: docker
+      prologue:
+        commands:
+        - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+        - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+        - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
       jobs:
       - name: "make cd"
         execution_time_limit:
           minutes: 120
         commands:
-        - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-        - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-        - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
         - >-
           if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then
               make image-all cd CONFIRM=true
+          fi
+      - name: "make cd-windows-upgrade"
+        execution_time_limit:
+          minutes: 120
+        commands:
+        - >-
+          if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then
               make build-windows-upgrade-archive image-tar-windows-all cd-windows-upgrade CONFIRM=true
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -880,10 +880,9 @@ cd-windows-upgrade:
 			image_tar="$(WINDOWS_UPGRADE_DIST)/image-$(GIT_VERSION)-$${win_ver}.tar"; \
 			image="$${registry}/$(WINDOWS_UPGRADE_IMAGE):$(GIT_VERSION)-windows-$${win_ver}"; \
 			echo Pushing image $${image} ...; \
-			$(CRANE_BINDMOUNT) push $${image_tar} $${image}$(double_quote) & \
+			$(CRANE_BINDMOUNT) push $${image_tar} $${image}$(double_quote); \
 			all_images="$${all_images} $${image}"; \
 		done; \
-		wait; \
 		$(DOCKER_MANIFEST) create --amend $${manifest_image} $${all_images}; \
 		for win_ver in $(WINDOWS_VERSIONS); do \
 			version=$$(docker manifest inspect mcr.microsoft.com/windows/nanoserver:$${win_ver} | grep "os.version" | head -n 1 | awk -F\" '{print $$4}'); \


### PR DESCRIPTION
## Description

With f111f7f75f8ac2aae93a47a7caa2821e38583c1c we now build push multiple images at once to quay.io/docker.io but we're hitting rate limits:

```
2021/10/30 00:18:33 pushing quay.io/calico/windows-upgrade:v3.22.0-0.dev-17-gf111f7f75f8a-windows-20H2: Head "https://quay.io/v2/calico/windows-upgrade/blobs/sha256:6ff5b479e8bb5a1b7e465fe3371f9530a3ca9f33c71520647b1894a39c35db1a": GET https://quay.io/v2/auth?scope=repository%3Acalico%2Fwindows-upgrade%3Apush%2Cpull&scope=repository%3Acalico%2Fwindows-upgrade%3Apull&service=quay.io: unexpected status code 429 Too Many Requests: <html>
<head><title>429 Too Many Requests</title></head>
<body bgcolor="white">
<center><h1>429 Too Many Requests</h1></center>
<hr><center>nginx/1.12.1</center>
</body>
</html>
```

This PR runs the image push sequentially for the Windows images and splits out the windows cd job into a separate job since the pushes to quay.io are slow.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
