### PR TITLE
Set empty node status if BGP is not enabled.

### DIFF
--- a/pkg/status/populators/bird_conn.go
+++ b/pkg/status/populators/bird_conn.go
@@ -49,9 +49,19 @@ func getBirdConn(ipv IPFamily) (*birdConn, error) {
 		log.Debugln("Failed to connect to BIRD socket in /var/run/calico, trying /var/run/bird")
 		c, err = net.Dial("unix", fmt.Sprintf("/var/run/bird/bird%s.ctl", birdSuffix))
 		if err != nil {
-			return nil, fmt.Errorf("Error querying BIRD: unable to connect to BIRDv%s socket: %v", ipv, err)
+			return nil, ErrorSocketConnection{Err: err, ipv: ipv}
 		}
 	}
 
 	return &birdConn{conn: c, ipv: ipv}, nil
+}
+
+// Error indicating connection to bird socket failed.
+type ErrorSocketConnection struct {
+	Err error
+	ipv IPFamily
+}
+
+func (e ErrorSocketConnection) Error() string {
+	return fmt.Sprintf("Error querying BIRD: unable to connect to BIRDv%s socket: %v", e.ipv, e.Err)
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR makes sure when calico-node failed to connect to BIRD socket, e.g. BGP not enabled, it return node status with BGP daemon state `NotReady` and empty BGP + Routes information.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
