### PR TITLE
windows: fix entrypoint not deleting the outer zip file

### DIFF
--- a/windows-upgrade/Dockerfile
+++ b/windows-upgrade/Dockerfile
@@ -30,13 +30,14 @@ USER ContainerAdministrator
 
 ENTRYPOINT cmd.exe \
 	/C \
-	copy /y c:\\CalicoBin\\calico-windows-upgrade.zip c:\\CalicoUpgrade & \
-	tar -x -f c:\\CalicoUpgrade\calico-windows-upgrade.zip -C c:\\CalicoUpgrade & \
-	del c:\\CalicoUpgrade\calico-windows-upgrade.zip & \
-	icacls.exe c:\\CalicoUpgrade & \
-	icacls.exe c:\\CalicoUpgrade /inheritance:r & \
-	icacls.exe c:\\CalicoUpgrade /grant:r SYSTEM:(OI)(CI)(F) & \
-	icacls.exe c:\\CalicoUpgrade /grant:r BUILTIN\Administrators:(OI)(CI)(F) & \
-	icacls.exe c:\\CalicoUpgrade /grant:r BUILTIN\Users:(OI)(CI)(RX) & \
-	icacls.exe c:\\CalicoUpgrade & \
+	copy /y c:\CalicoBin\calico-windows-upgrade.zip c:\CalicoUpgrade & \
+	tar -x -f c:\CalicoUpgrade\calico-windows-upgrade.zip -C c:\CalicoUpgrade & \
+	del c:\CalicoUpgrade\calico-windows-upgrade.zip & \
+	dir c:\CalicoUpgrade & \
+	icacls.exe c:\CalicoUpgrade & \
+	icacls.exe c:\CalicoUpgrade /inheritance:r & \
+	icacls.exe c:\CalicoUpgrade /grant:r SYSTEM:(OI)(CI)(F) & \
+	icacls.exe c:\CalicoUpgrade /grant:r BUILTIN\Administrators:(OI)(CI)(F) & \
+	icacls.exe c:\CalicoUpgrade /grant:r BUILTIN\Users:(OI)(CI)(RX) & \
+	icacls.exe c:\CalicoUpgrade & \
 	ping -t localhost > NUL


### PR DESCRIPTION
## Description

This removes the double backslashes that aren't needed but also break
the 'del' command.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
