### PR TITLE
IPv6: Increase blockSize maximum to 64 bits

### DIFF
--- a/pkg/lifecycle/startup/startup.go
+++ b/pkg/lifecycle/startup/startup.go
@@ -603,14 +603,14 @@ func parseBlockSizeEnvironment(envValue string) int {
 
 // validateBlockSize check if blockSize is valid
 func validateBlockSize(version int, blockSize int) {
-	// 20 to 32 (inclusive) for IPv4 and 116 to 128 (inclusive) for IPv6
+	// 20 to 32 (inclusive) for IPv4 and 64 to 128 (inclusive) for IPv6
 	if version == 4 {
 		if blockSize < 20 || blockSize > 32 {
 			log.Errorf("Invalid blocksize %d for version %d", blockSize, version)
 			utils.Terminate()
 		}
 	} else if version == 6 {
-		if blockSize < 116 || blockSize > 128 {
+		if blockSize < 64 || blockSize > 128 {
 			log.Errorf("Invalid blocksize %d for version %d", blockSize, version)
 			utils.Terminate()
 		}


### PR DESCRIPTION
## Description
Current IPv6 blockSize limit to 116 bits which was introduced by #339 is against of best practices:
> The IPv6 subnet size is standardized by fixing the size of the host identifier portion of an address to 64 bits.

- source: https://en.wikipedia.org/wiki/IPv6

Also articles like https://itnext.io/how-to-run-ipv6-enabled-docker-containers-on-aws-87e090ab0397 and https://itnext.io/kubernetes-multi-cluster-networking-made-simple-c8f26827813 highly recommend to use at least /80

Also there is known bugs on Docker which comes with those smaller networks like: https://github.com/moby/moby/issues/40275

So this PR will give possibility for user to configure bits between 64-115 too. Later it might make sense to change even default example to that /80 but I did leave it out for now.

Docs PR: https://github.com/projectcalico/calico/pull/5080

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
