### PR TITLE
Update centos.repo now that 8.4.2105 is deprecated

### DIFF
--- a/centos.repo
+++ b/centos.repo
@@ -1,13 +1,13 @@
 [centos-8-base-os]
 name = CentOS - BaseOS
-baseurl = https://mirror.rackspace.com/CentOS/8.4.2105/BaseOS/x86_64/os/
+baseurl = https://vault.centos.org/8.4.2105/BaseOS/x86_64/os/
 enabled = 1
 gpgkey = https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 gpgcheck = 1
 
 [centos-8-appstream]
 name = CentOS - AppStream
-baseurl = https://mirror.rackspace.com/CentOS/8.4.2105/AppStream/x86_64/os/
+baseurl = https://vault.centos.org/8.4.2105/AppStream/x86_64/os/
 enabled = 1
 gpgkey = https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 gpgcheck = 1


### PR DESCRIPTION
## Description

8.4.2105 has been moved to vault.centos.org and is not available at https://mirror.rackspace.com/CentOS/8.4.2105/ (or any of the other mirrors)
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
