### PR TITLE
Automated cherry pick of #1344: Update centos.repo now that 8.4.2105 is deprecated

### DIFF
--- a/centos.repo
+++ b/centos.repo
@@ -1,13 +1,13 @@
 [centos-8-base-os]
 name = CentOS - BaseOS
-baseurl = https://mirror.rackspace.com/CentOS/8.4.2105/BaseOS/x86_64/os/
+baseurl = https://vault.centos.org/8.4.2105/BaseOS/x86_64/os/
 enabled = 1
 gpgkey = https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 gpgcheck = 1
 
 [centos-8-appstream]
 name = CentOS - AppStream
-baseurl = https://mirror.rackspace.com/CentOS/8.4.2105/AppStream/x86_64/os/
+baseurl = https://vault.centos.org/8.4.2105/AppStream/x86_64/os/
 enabled = 1
 gpgkey = https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 gpgcheck = 1


### PR DESCRIPTION
Cherry pick of #1344 on release-v3.19.

#1344: Update centos.repo now that 8.4.2105 is deprecated