### PR TITLE
Add newline to final fmt.Printf calls

### DIFF
--- a/pkg/calicoclient/calicoclient.go
+++ b/pkg/calicoclient/calicoclient.go
@@ -14,12 +14,12 @@ func CreateClient() (*apiconfig.CalicoAPIConfig, client.Interface) {
 	// Load the client config from environment.
 	cfg, err := apiconfig.LoadClientConfig("")
 	if err != nil {
-		fmt.Printf("ERROR: Error loading datastore config: %s", err)
+		fmt.Printf("ERROR: Error loading datastore config: %s\n", err)
 		os.Exit(1)
 	}
 	c, err := client.New(*cfg)
 	if err != nil {
-		fmt.Printf("ERROR: Error accessing the Calico datastore: %s", err)
+		fmt.Printf("ERROR: Error accessing the Calico datastore: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -57,7 +57,7 @@ func Run(bird, bird6, felixReady, felixLive, birdLive, bird6Live bool, threshold
 	readinessChecks := bird || felixReady || bird6
 
 	if !livenessChecks && !readinessChecks {
-		fmt.Printf("calico/node check error: must specify at least one of -bird-live, -bird6-live, -felix-live, -bird, -bird6, or -felix")
+		fmt.Printf("calico/node check error: must specify at least one of -bird-live, -bird6-live, -felix-live, -bird, -bird6, or -felix\n")
 		os.Exit(1)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), thresholdTime)
@@ -118,7 +118,7 @@ func Run(bird, bird6, felixReady, felixLive, birdLive, bird6Live bool, threshold
 		})
 	}
 	if err := g.Wait(); err != nil {
-		fmt.Printf("%s", err)
+		fmt.Printf("%s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Description

This is a bug fix that adds a `\n` to calls of `fmt.Printf`. When the last log line doesn't include a newline, some log ingestion programs (e.g., filebeat) chokes on the log line, forever thinking that the line hasn't finished printing.

## Release Note

```release-note
Add newline to the end of some log lines that were missing it
```
