### PR TITLE
Make more room on the semaphore build machine

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ global_job_config:
   prologue:
     commands:
       # make some room on the disk
-      - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
+      - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
       # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
       # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
       # how much we churn docker containers during the build.  Disable it.


### PR DESCRIPTION
## Description

Build is failing quite often now, Semaphore has suggested we try bumping the instance size since the symptoms indicate the failures may be due to disk space.

This PR adds a few more directories to clean up to further reduce the size by ~ 2GB. We already do this in other internal repos.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
