### PR TITLE
windows: move install-calico-windows.ps1 here

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -819,8 +819,7 @@ install-calico-windows-script $(WINDOWS_INSTALL_SCRIPT): $(WINDOWS_GEN_INSTALL_S
 		-product "$(WINDOWS_INSTALL_SCRIPT_PRODUCT)" \
 		-version $(GIT_VERSION) \
 		-templatePath windows-packaging/install-calico-windows.ps1.tpl \
-		-baseUrl $(WINDOWS_ARCHIVE_BASE_URL) \
-		-debug true > $(WINDOWS_INSTALL_SCRIPT)
+		-baseUrl $(WINDOWS_ARCHIVE_BASE_URL) > $(WINDOWS_INSTALL_SCRIPT)
 
 # Copy the install-calico-windows.ps1 script to the temporary directory where we
 # build the windows upgrade zip file.

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,16 @@ NODE_CONTAINER_BIN_DIR=./dist/bin/
 NODE_CONTAINER_BINARY = $(NODE_CONTAINER_BIN_DIR)/calico-node-$(ARCH)
 WINDOWS_BINARY = $(NODE_CONTAINER_BIN_DIR)/calico-node.exe
 
+WINDOWS_GEN_INSTALL_SCRIPT_BIN := hack/bin/gen-install-calico-windows-script
+
+# Base URL of the Calico for Windows installation zip archive.
+# This can be overridden for dev releases.
+WINDOWS_ARCHIVE_BASE_URL ?= https://docs.projectcalico.org
+
+# This is either "Calico" or "Calico Enterprise"
+WINDOWS_INSTALL_SCRIPT_PRODUCT ?= Calico
+WINDOWS_INSTALL_SCRIPT := dist/install-calico-windows.ps1
+
 # Variables for the Windows packaging.
 # Name of the Windows release ZIP archive.
 WINDOWS_ARCHIVE_ROOT := windows-packaging/CalicoWindows
@@ -198,6 +208,8 @@ clean: clean-windows-upgrade
 	rm -f $(WINDOWS_ARCHIVE_ROOT)/libs/hns/hns.psm1
 	rm -f $(WINDOWS_ARCHIVE_ROOT)/libs/hns/License.txt
 	rm -f $(WINDOWS_ARCHIVE_ROOT)/cni/*.exe
+	rm -f $(WINDOWS_GEN_INSTALL_SCRIPT_BIN)
+	rm -f $(WINDOWS_INSTALL_SCRIPT)
 	rm -f $(WINDOWS_UPGRADE_INSTALL_FILE)
 	rm -f $(WINDOWS_UPGRADE_BUILD)/*.zip
 	rm -rf filesystem/included-source
@@ -637,6 +649,8 @@ endif
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	# Generate the `latest` node images.
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
+	# Generate the install-calico-windows.ps1 script
+	$(MAKE) install-calico-windows-script
 	# Generate the Windows zip archives.
 	$(MAKE) release-windows-archive
 	$(MAKE) release-windows-upgrade-archive
@@ -680,6 +694,11 @@ endif
 	ghr -u projectcalico -r node \
 		-n $(VERSION) \
 		$(VERSION) $(WINDOWS_ARCHIVE)
+
+	# Update the release with the install-calico-windows.ps1 file too.
+	ghr -u projectcalico -r node \
+		-n $(VERSION) \
+		$(VERSION) $(WINDOWS_INSTALL_SCRIPT)
 
 	@echo "Finalize the GitHub release based on the pushed tag."
 	@echo ""
@@ -786,24 +805,27 @@ $(WINDOWS_UPGRADE_SCRIPT): $(WINDOWS_UPGRADE_DIST_STAGE)
 $(WINDOWS_UPGRADE_INSTALL_ZIP): build-windows-archive $(WINDOWS_UPGRADE_DIST_STAGE)
 	cp $(WINDOWS_ARCHIVE) $@
 
-# Get the install script into the temporary directory where we build the windows
-# upgrade zip file. The version of the install script depends on whether there
-# is a released version for the branch; otherwise the master version of the
-# script is used.
-$(WINDOWS_UPGRADE_INSTALL_FILE): $(WINDOWS_UPGRADE_DIST_STAGE)
-	# Truncated git version in the vX.Y version string our docs site uses.
-	$(eval ver := $(shell echo $(WINDOWS_ARCHIVE_TAG) | sed -ne 's/\(v[0-9]\+\.[0-9]\+\).*/\1/p' ))
-	# The vX.Y.Z version string.
-	$(eval fullver := $(shell echo $(WINDOWS_ARCHIVE_TAG) | sed -ne 's/\(v[0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' ))
-	@echo vX.Y version is $(ver)
-	@echo vX.Y.Z version is $(fullver)
-	@if git show-ref --tags $(fullver) ; then \
-		echo "Tag $(fullver) exists, using released version of installation script" ; \
-		curl --fail https://docs.projectcalico.org/archive/$(ver)/scripts/install-calico-windows.ps1 -o $(WINDOWS_UPGRADE_INSTALL_FILE) ; \
-	else \
-		echo "Tag $(fullver) doesn't exist yet, using master version of installation script" ; \
-		curl --fail https://docs.projectcalico.org/master/scripts/install-calico-windows.ps1 -o $(WINDOWS_UPGRADE_INSTALL_FILE) ; \
-	fi
+# Build the tool to generate the install-calico-windows.ps1 installation script.
+$(WINDOWS_GEN_INSTALL_SCRIPT_BIN):
+	mkdir -p hack/bin
+	$(DOCKER_RUN) $(CALICO_BUILD) sh -c ' \
+	$(GIT_CONFIG_SSH) \
+	go build -o $@ ./hack/gen-install-calico-windows-script'
+
+# Generate the install-calico-windows.ps1 installation script.
+# For dev releases, override WINDOWS_ARCHIVE_BASE_URL.
+install-calico-windows-script $(WINDOWS_INSTALL_SCRIPT): $(WINDOWS_GEN_INSTALL_SCRIPT_BIN)
+	$(WINDOWS_GEN_INSTALL_SCRIPT_BIN) \
+		-product "$(WINDOWS_INSTALL_SCRIPT_PRODUCT)" \
+		-version $(GIT_VERSION) \
+		-templatePath windows-packaging/install-calico-windows.ps1.tpl \
+		-baseUrl $(WINDOWS_ARCHIVE_BASE_URL) \
+		-debug true > $(WINDOWS_INSTALL_SCRIPT)
+
+# Copy the install-calico-windows.ps1 script to the temporary directory where we
+# build the windows upgrade zip file.
+$(WINDOWS_UPGRADE_INSTALL_FILE): $(WINDOWS_UPGRADE_DIST_STAGE) $(WINDOWS_INSTALL_SCRIPT)
+	cp $(WINDOWS_INSTALL_SCRIPT) $@
 
 # Produces the Windows upgrade ZIP archive for the release.
 release-windows-upgrade-archive: release-prereqs

--- a/hack/gen-install-calico-windows-script/main.go
+++ b/hack/gen-install-calico-windows-script/main.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"text/template"
+)
+
+type install struct {
+	Product     string `json:"product"`
+	ProductName string `json:"productName"`
+	Version     string `json:"version"`
+	BaseUrl     string `json:"baseUrl"`
+	RootDir     string `json:"rootDir"`
+	ZipFileName string `json:"zipFileName"`
+}
+
+func newInstall(product, version, baseUrl string) (install, error) {
+	data := install{
+		Product: product,
+		Version: version,
+		BaseUrl: baseUrl,
+	}
+	var productName, rootDir, zipFileName string
+
+	if product == "Calico" {
+		productName = "Calico for Windows"
+		rootDir = "CalicoWindows"
+		zipFileName = "calico-windows.zip"
+	} else if product == "Calico Enterprise" {
+		productName = "Tigera Calico for Windows"
+		rootDir = "TigeraCalico"
+		zipFileName = "tigera-calico-windows.zip"
+	} else {
+		return data, fmt.Errorf("invalid product: %v", product)
+	}
+
+	data.ProductName = productName
+	data.RootDir = rootDir
+	data.ZipFileName = zipFileName
+	return data, nil
+}
+
+var (
+	product      string
+	version      string
+	templatePath string
+	baseUrl      string
+	debug        bool
+)
+
+func main() {
+	flag.StringVar(&product, "product", "", `product to generate install script for. either "Calico" or "Calico Enterprise"`)
+	flag.StringVar(&version, "version", "", `version`)
+	flag.StringVar(&templatePath, "templatePath", "", `path to the template for the installation script`)
+	flag.StringVar(&baseUrl, "baseUrl", "", `URL where the installation zip file will be hosted. Required for Calico only`)
+	flag.BoolVar(&debug, "debug", false, `enable debug logging`)
+	flag.Parse()
+
+	if debug {
+		log.Printf("product: %v, version: %v, templatePath: %v, baseUrl: %v", product, version, templatePath, baseUrl)
+	}
+
+	if product == "" || version == "" || templatePath == "" {
+		log.Fatalf("product, version, templatePath, and baseUrl must all be specified")
+	}
+
+	if product == "Calico" && baseUrl == "" {
+		log.Fatalf("baseUrl is required for Calico")
+	}
+
+	if _, err := os.Stat(templatePath); errors.Is(err, os.ErrNotExist) {
+		log.Fatalf("templatePath %v does not exist", templatePath)
+	}
+
+	data, err := newInstall(product, version, baseUrl)
+	if err != nil {
+		log.Fatalf("error generating installation script data: %v", err)
+	}
+
+	if debug {
+		log.Printf("using install data: %+v", data)
+	}
+
+	t, err := template.ParseFiles(templatePath)
+	if err != nil {
+		log.Fatalf("error parsing template: %v", err)
+	}
+
+	err = t.Execute(os.Stdout, data)
+	if err != nil {
+		log.Fatalf("error rendering template: %v", err)
+	}
+}

--- a/hack/gen-install-calico-windows-script/main.go
+++ b/hack/gen-install-calico-windows-script/main.go
@@ -66,6 +66,26 @@ var (
 	baseUrl      string
 )
 
+// This program generates the Calico for Windows installation script for a given product, version and baseUrl.
+//
+// Examples:
+//
+// For Calico v3.21.1:
+//
+// gen-install-calico-windows-script \
+//    -product Calico \
+//    -version v3.21.1 \
+//    -templatePath windows-packaging/install-calico-windows.ps1.tpl \
+//    -baseUrl https://docs.projectcalico.org > install-calico-windows.ps1
+//
+//
+// For Calico Enterprise v3.11.0:
+//
+// gen-install-calico-windows-script \
+//    -product "Calico Enterprise" \
+//    -version v3.11.0 \
+//    -templatePath windows-packaging/install-calico-windows.ps1.tpl \
+//    -baseUrl https://docs.tigera.io > install-calico-windows.ps1
 func main() {
 	flag.StringVar(&product, "product", "", `product to generate install script for. either "Calico" or "Calico Enterprise"`)
 	flag.StringVar(&version, "version", "", `version`)

--- a/windows-packaging/install-calico-windows.ps1.tpl
+++ b/windows-packaging/install-calico-windows.ps1.tpl
@@ -1,0 +1,439 @@
+# Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+<#
+.DESCRIPTION
+    This script installs and starts {{.Product}} services on a Windows node.
+
+    Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+#>
+
+Param(
+
+{{- if eq .Product "Calico" }}
+{{- if eq .BaseUrl "https://docs.projectcalico.org" }}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{.Version}}/",
+{{- else }}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{.BaseUrl}}/files/windows/",
+{{- end }}
+    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{.Version}}.zip",
+{{- end }}
+    [parameter(Mandatory = $false)] $KubeVersion="",
+    [parameter(Mandatory = $false)] $DownloadOnly="no",
+    [parameter(Mandatory = $false)] $Datastore="kubernetes",
+    [parameter(Mandatory = $false)] $EtcdEndpoints="",
+    [parameter(Mandatory = $false)] $EtcdTlsSecretName="",
+    [parameter(Mandatory = $false)] $EtcdKey="",
+    [parameter(Mandatory = $false)] $EtcdCert="",
+    [parameter(Mandatory = $false)] $EtcdCaCert="",
+    [parameter(Mandatory = $false)] $ServiceCidr="10.96.0.0/12",
+    [parameter(Mandatory = $false)] $DNSServerIPs="10.96.0.10",
+    [parameter(Mandatory = $false)] $CalicoBackend=""
+)
+
+function DownloadFiles()
+{
+    Write-Host "Creating CNI directory"
+    md $BaseDir\cni\config -ErrorAction Ignore
+
+    Write-Host "Downloading Windows Kubernetes scripts"
+    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
+    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/InstallImages.ps1 -Destination $BaseDir\InstallImages.ps1
+    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -Destination $BaseDir\Dockerfile
+}
+
+function PrepareDockerFile()
+{
+    # Update Dockerfile for windows
+    $OSInfo = (Get-ComputerInfo  | select WindowsVersion, OsBuildNumber)
+    $OSNumber = $OSInfo.WindowsVersion
+    $ExistOSNumber = cat c:\k\Dockerfile | findstr.exe $OSNumber
+    if (!$ExistOSNumber)
+    {
+        Write-Host "Update dockerfile for $OSNumber"
+
+        $ImageWithOSNumber = "nanoserver:" + $OSNumber
+        (get-content c:\k\Dockerfile) | foreach-object {$_ -replace "nanoserver", "$ImageWithOSNumber"} | set-content c:\k\Dockerfile
+    }
+}
+
+function PrepareKubernetes()
+{
+    DownloadFiles
+    PrepareDockerFile
+    ipmo C:\k\hns.psm1
+
+    # Prepare POD infra Images
+    c:\k\InstallImages.ps1
+
+    InstallK8sBinaries
+}
+
+function InstallK8sBinaries()
+{
+    Install-7Zip
+    $Source = "" | Select Release
+    $Source.Release=$KubeVersion
+    InstallKubernetesBinaries -Destination $BaseDir -Source $Source
+    cp c:\k\kubernetes\node\bin\*.exe c:\k
+}
+
+function GetPlatformType()
+{
+    # AKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -EQ azure
+    if ($hnsNetwork.name -EQ "azure") {
+        return ("aks")
+    }
+
+    # EKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -like "vpcbr*"
+    if ($hnsNetwork.name -like "vpcbr*") {
+        return ("eks")
+    }
+
+    # EC2
+    $restError = $null
+    Try {
+        $awsNodeName=Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("ec2")
+    }
+
+    # GCE
+    $restError = $null
+    Try {
+        $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("gce")
+    }
+
+    return ("bare-metal")
+}
+
+function GetBackendType()
+{
+    param(
+        [parameter(Mandatory=$true)] $CalicoNamespace,
+        [parameter(Mandatory=$false)] $KubeConfigPath = "$RootDir\calico-kube-config"
+    )
+
+    if (-Not [string]::IsNullOrEmpty($CalicoBackend)) {
+        return $CalicoBackend
+    }
+
+    # Auto detect backend type
+    if ($Datastore -EQ "kubernetes") {
+        $encap=c:\k\kubectl.exe --kubeconfig="$RootDir\calico-kube-config" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}' -n $CalicoNamespace
+        if ($encap -EQ "true") {
+            throw "{{.Product}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+        }
+
+        $encap=c:\k\kubectl.exe --kubeconfig="$RootDir\calico-kube-config" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.vxlanEnabled}' -n $CalicoNamespace
+        if ($encap -EQ "true") {
+            return ("vxlan")
+        }
+        return ("bgp")
+    } else {
+        $CalicoBackend=c:\k\kubectl.exe --kubeconfig="$RootDir\calico-kube-config" get configmap calico-config -n $CalicoNamespace -o jsonpath='{.data.calico_backend}'
+        if ($CalicoBackend -EQ "vxlan") {
+            return ("vxlan")
+        }
+        return ("bgp")
+    }
+}
+
+function GetCalicoNamespace() {
+    param(
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get ns calico-system
+    if ([string]::IsNullOrEmpty($name)) {
+        write-host "Calico running in kube-system namespace"
+        return ("kube-system")
+    }
+    write-host "Calico running in calico-system namespace"
+    return ("calico-system")
+}
+
+function GetCalicoKubeConfig()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$false)] $SecretName = "calico-node",
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    # On EKS, we need to have AWS tools loaded for kubectl authentication.
+    $eksAWSToolsModulePath="C:\Program Files (x86)\AWS Tools\PowerShell\AWSPowerShell\AWSPowerShell.psd1"
+    if (Test-Path $eksAWSToolsModulePath) {
+        Write-Host "AWSPowerShell module exists, loading $eksAWSToolsModulePath ..."
+        Import-Module $eksAWSToolsModulePath
+    }
+
+    $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretName | select -first 1
+    if ([string]::IsNullOrEmpty($name)) {
+        throw "$SecretName service account does not exist."
+    }
+    $ca=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.ca\.crt}' -n $CalicoNamespace
+    $tokenBase64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.token}' -n $CalicoNamespace
+    $token=[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($tokenBase64))
+
+    $server=findstr https:// $KubeConfigPath
+
+    (Get-Content $RootDir\calico-kube-config.template).replace('<ca>', $ca).replace('<server>', $server.Trim()).replace('<token>', $token) | Set-Content $RootDir\calico-kube-config -Force
+}
+
+function EnableWinDsrForEKS()
+{
+    $OSInfo = (Get-ComputerInfo  | select WindowsVersion, OsBuildNumber)
+    $PlatformSupportDSR = (($OSInfo.WindowsVersion -as [int]) -GE 1903 -And ($OSInfo.OsBuildNumber -as [int]) -GE 18317)
+
+    if (-Not $PlatformSupportDSR) {
+        Write-Host "WinDsr is not supported ($OSInfo)"
+        return
+    }
+
+    # Update and restart kube-proxy if WinDSR is not enabled by default.
+    $Path = Get-CimInstance -Query 'select * from win32_service where name="kube-proxy"' | Select -ExpandProperty pathname
+    if ($Path -like "*--enable-dsr=true*") {
+        Write-Host "WinDsr is enabled by default."
+    } else {
+        $UpdatedPath = $Path + " --enable-dsr=true --feature-gates=WinDSR=true"
+        Get-CimInstance win32_service -filter 'Name="kube-proxy"' | Invoke-CimMethod -Name Change -ArgumentList @($null,$null,$null,$null,$null,$UpdatedPath)
+        Restart-Service -name "kube-proxy"
+        Write-Host "WinDsr has been enabled for kube-proxy."
+    }
+}
+
+function SetupEtcdTlsFiles()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$true)] $SecretName,
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $path = "$RootDir\etcd-tls"
+
+    $found=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -n $CalicoNamespace
+    if ([string]::IsNullOrEmpty($found)) {
+        throw "$SecretName does not exist."
+    }
+
+    $keyB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-key}' -n $CalicoNamespace
+    $certB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-cert}' -n $CalicoNamespace
+    $caB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-ca}' -n $CalicoNamespace
+
+    New-Item -Type Directory -Path $path -Force
+
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($keyB64)) | Set-Content "$path\server.key" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($certB64)) | Set-Content "$path\server.crt" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($caB64)) | Set-Content "$path\ca.crt" -Force
+
+    $script:EtcdKey = "$path\server.key"
+    $script:EtcdCert = "$path\server.crt"
+    $script:EtcdCaCert = "$path\ca.crt"
+}
+
+function SetConfigParameters {
+    param(
+        [parameter(Mandatory=$true)] $OldString,
+        [parameter(Mandatory=$true)] $NewString
+    )
+
+    (Get-Content $RootDir\config.ps1).replace($OldString, $NewString) | Set-Content $RootDir\config.ps1 -Force
+}
+
+function SetAKSCalicoStaticRules {
+    $fileName  = [Io.path]::Combine("$RootDir", "static-rules.json")
+    echo '{
+    "Provider": "AKS",
+    "Rules": [
+        {
+            "Name": "EndpointPolicy",
+            "Rule": {
+                "Action": "Block",
+                "Direction": "Out",
+                "Id": "block-wireserver",
+                "Priority": 200,
+                "Protocol": 6,
+                "RemoteAddresses": "168.63.129.16/32",
+                "RemotePorts": "80",
+                "RuleType": "Switch",
+                "Type": "ACL"
+            }
+        }
+    ],
+    "version": "0.1.0"
+}' | Out-File -encoding ASCII -filepath $fileName
+}
+
+function StartCalico()
+{
+    Write-Host "`nStart {{.ProductName}}...`n"
+
+    pushd
+    cd $RootDir
+    .\install-calico.ps1
+    popd
+    Write-Host "`n{{.ProductName}} Started`n"
+}
+
+$BaseDir="c:\k"
+$RootDir="c:\{{.RootDir}}"
+$CalicoZip="c:\{{.ZipFileName}}"
+
+# Must load the helper modules before doing anything else.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$helper = "$BaseDir\helper.psm1"
+$helperv2 = "$BaseDir\helper.v2.psm1"
+md $BaseDir -ErrorAction Ignore
+if (!(Test-Path $helper))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -O $BaseDir\helper.psm1
+}
+if (!(Test-Path $helperv2))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $BaseDir\helper.v2.psm1
+}
+ipmo -force $helper
+ipmo -force $helperv2
+
+if (!(Test-Path $CalicoZip))
+{
+{{- if eq .Product "Calico Enterprise" }}
+    throw "Cannot find {{.ProductName}} zip file $CalicoZip."
+{{- else if eq .Product "Calico" }}
+    Write-Host "$CalicoZip not found, downloading {{.ProductName}} release..."
+    DownloadFile -Url $ReleaseBaseURL/$ReleaseFile -Destination c:\calico-windows.zip
+{{- else }}
+    throw "Invalid product name - did prodname in _config.yml change?"
+{{- end }}
+}
+
+$platform=GetPlatformType
+
+if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
+    PrepareKubernetes
+}
+
+if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where Status -EQ Running) -NE $null) {
+Write-Host "Calico services are still running. In order to re-run the installation script, stop the CalicoNode and CalicoFelix services or uninstall them by running: $RootDir\uninstall-calico.ps1"
+Exit
+}
+
+Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
+Write-Host "Unzip {{.ProductName}} release..."
+Expand-Archive -Force $CalicoZip c:\
+
+Write-Host "Setup {{.ProductName}}..."
+SetConfigParameters -OldString '<your datastore type>' -NewString $Datastore
+SetConfigParameters -OldString '<your etcd endpoints>' -NewString "$EtcdEndpoints"
+
+if (-Not [string]::IsNullOrEmpty($EtcdTlsSecretName)) {
+    $calicoNs = GetCalicoNamespace
+    SetupEtcdTlsFiles -SecretName "$EtcdTlsSecretName" -CalicoNamespace $calicoNs
+}
+SetConfigParameters -OldString '<your etcd key>' -NewString "$EtcdKey"
+SetConfigParameters -OldString '<your etcd cert>' -NewString "$EtcdCert"
+SetConfigParameters -OldString '<your etcd ca cert>' -NewString "$EtcdCaCert"
+SetConfigParameters -OldString '<your service cidr>' -NewString $ServiceCidr
+SetConfigParameters -OldString '<your dns server ips>' -NewString $DNSServerIPs
+
+if ($platform -EQ "aks") {
+    Write-Host "Setup {{.ProductName}} for AKS..."
+    $Backend="none"
+    SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="none"'
+    SetConfigParameters -OldString 'KUBE_NETWORK = "Calico.*"' -NewString 'KUBE_NETWORK = "azure.*"'
+
+    $calicoNs = "calico-system"
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+
+    SetAKSCalicoStaticRules
+}
+if ($platform -EQ "eks") {
+    EnableWinDsrForEKS
+
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup Calico for Windows for EKS, node name $awsNodeName ..."
+    $Backend = "none"
+    $awsNodeNameQuote = """$awsNodeName"""
+    SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$awsNodeNameQuote"
+    SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="none"'
+    SetConfigParameters -OldString 'KUBE_NETWORK = "Calico.*"' -NewString 'KUBE_NETWORK = "vpc.*"'
+
+    $calicoNs = GetCalicoNamespace -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+}
+if ($platform -EQ "ec2") {
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup Calico for Windows for AWS, node name $awsNodeName ..."
+    $awsNodeNameQuote = """$awsNodeName"""
+    SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$awsNodeNameQuote"
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="windows-bgp"'
+    }
+}
+if ($platform -EQ "gce") {
+    $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    Write-Host "Setup {{.ProductName}} for GCE, node name $gceNodeName ..."
+    $gceNodeNameQuote = """$gceNodeName"""
+    SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$gceNodeNameQuote"
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="windows-bgp"'
+    }
+}
+if ($platform -EQ "bare-metal") {
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="windows-bgp"'
+    }
+}
+
+if ($DownloadOnly -EQ "yes") {
+    Write-Host "Downloaded {{.ProductName}}. Update c:\{{.RootDir}}\config.ps1 and run c:\CalicoWindows\install-calico.ps1"
+    Exit
+}
+
+StartCalico
+
+if ($Backend -NE "none") {
+    New-NetFirewallRule -Name KubectlExec10250 -Description "Enable kubectl exec and log" -Action Allow -LocalPort 10250 -Enabled True -DisplayName "kubectl exec 10250" -Protocol TCP -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Description

This PR duplicates the creation of the Calico for Windows installation [script](https://github.com/projectcalico/calico/blob/master/scripts/install-calico-windows.ps1). The installation script is hosted on docs.projectcalico.org and is also bundled into in the calico windows upgrader image.

**Test of the rendered file compared with https://docs.projectcalico.org/scripts/install-calico-windows.ps1**
```
$ make install-calico-windows-script GIT_VERSION=v3.21.1
"Build dependency versions"
BIRD_VERSION          = v0.3.3-184-g202a2186
"Test dependency versions"
CNI_VER               = master
"Calico git version"
GIT_VERSION           = v3.21.1
mkdir -p hack/bin
mkdir -p .go-pkg-cache bin /home/lmm/go/pkg/mod && docker run --rm --net=host --init -v /tmp/ssh-KKtMe9Kgne/agent.1885232:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent -e GO111MODULE=on -v /home/lmm/go/pkg/mod:/go/pkg/mod:rw -e LOCAL_USER_ID=1000 -e GOCACHE=/go-cache -e GOARCH=amd64 -e GOPATH=/go -e OS=linux -e GOOS=linux -e GOFLAGS= -v /home/lmm/go/src/github.com/projectcalico/node:/go/src/github.com/projectcalico/node:rw -v /home/lmm/go/src/github.com/projectcalico/node/.go-pkg-cache:/go-cache:rw -w /go/src/github.com/projectcalico/node calico/go-build:v0.58 sh -c ' \
 \
go build -o hack/bin/gen-install-calico-windows-script ./hack/gen-install-calico-windows-script'
Starting with UID : 1000
hack/bin/gen-install-calico-windows-script \
        -product "Calico" \
        -version v3.21.1 \
        -templatePath windows-packaging/install-calico-windows.ps1.tpl \
        -baseUrl https://docs.projectcalico.org \
        -debug true > dist/install-calico-windows.ps1
2021/11/24 15:52:25 product: Calico, version: v3.21.1, templatePath: windows-packaging/install-calico-windows.ps1.tpl, baseUrl: https://docs.projectcalico.org
2021/11/24 15:52:25 using install data: {Product:Calico ProductName:Calico for Windows Version:v3.21.1 BaseUrl:https://docs.projectcalico.org RootDir:CalicoWindows ZipFileName:calico-windows.zip}


$ diff dist/install-calico-windows.ps1 <(curl -L https://docs.projectcalico.org/scripts/install-calico-windows.ps1)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 17101  100 17101    0     0  16765      0  0:00:01  0:00:01 --:--:-- 16765
1c1
< # Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
---
> # Copyright (c) 2020 Tigera, Inc. All rights reserved.
418c418
<     Write-Host "Downloaded Calico for Windows. Update c:\CalicoWindows\config.ps1 and run c:\CalicoWindows\install-calico.ps1"
---
>     Write-Host "Dowloaded Calico for Windows. Update c:\CalicoWindows\config.ps1 and run c:\CalicoWindows\install-calico.ps1"
```
Note: This differences are bugs in the current version of the script in the calico repo.

**Test of the rendered file compared with https://docs.tigera.io/scripts/install-calico-windows.ps1**

```
$ make install-calico-windows-script GIT_VERSION=v3.11.0 WINDOWS_INSTALL_SCRIPT_PRODUCT="Calico Enterprise"
"Build dependency versions"
BIRD_VERSION          = v0.3.3-184-g202a2186
"Test dependency versions"
CNI_VER               = master
"Calico git version"
GIT_VERSION           = v3.11.0
mkdir -p hack/bin
mkdir -p .go-pkg-cache bin /home/lmm/go/pkg/mod && docker run --rm --net=host --init -v /tmp/ssh-KKtMe9Kgne/agent.1885232:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent -e GO111MODULE=on -v /home/lmm/go/pkg/mod:/go/pkg/mod:rw -e LOCAL_USER_ID=1000 -e GOCACHE=/go-cache -e GOARCH=amd64 -e GOPATH=/go -e OS=linux -e GOOS=linux -e GOFLAGS= -v /home/lmm/go/src/github.com/projectcalico/node:/go/src/github.com/projectcalico/node:rw -v /home/lmm/go/src/github.com/projectcalico/node/.go-pkg-cache:/go-cache:rw -w /go/src/github.com/projectcalico/node calico/go-build:v0.58 sh -c ' \
 \
go build -o hack/bin/gen-install-calico-windows-script ./hack/gen-install-calico-windows-script'
Starting with UID : 1000
hack/bin/gen-install-calico-windows-script \
        -product "Calico Enterprise" \
        -version v3.11.0 \
        -templatePath windows-packaging/install-calico-windows.ps1.tpl \
        -baseUrl https://docs.projectcalico.org \
        -debug true > dist/install-calico-windows.ps1
2021/11/24 15:53:21 product: Calico Enterprise, version: v3.11.0, templatePath: windows-packaging/install-calico-windows.ps1.tpl, baseUrl: https://docs.projectcalico.org
2021/11/24 15:53:21 using install data: {Product:Calico Enterprise ProductName:Tigera Calico for Windows Version:v3.11.0 BaseUrl:https://docs.projectcalico.org RootDir:TigeraCalico ZipFileName:tigera-calico-windows.zip}


$ diff dist/install-calico-windows.ps1 <(curl -L https://docs.tigera.io/scripts/install-calico-windows.ps1)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16881  100 16881    0     0  18489      0 --:--:-- --:--:-- --:--:-- 18469
1c1
< # Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
---
> # Copyright (c) 2020 Tigera, Inc. All rights reserved.
```
The difference is an out-of-date copyright notice in the published version.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
