### PR TITLE
windows: pass ExceptUpgradeService param to stop-calico.ps1 as well

### DIFF
--- a/windows-packaging/CalicoWindows/uninstall-calico.ps1
+++ b/windows-packaging/CalicoWindows/uninstall-calico.ps1
@@ -25,7 +25,7 @@ Test-CalicoConfiguration
 $ErrorActionPreference = 'SilentlyContinue'
 
 Write-Host "Stopping Calico if it is running..."
-& $PSScriptRoot\stop-calico.ps1
+& $PSScriptRoot\stop-calico.ps1 -ExceptUpgradeService $ExceptUpgradeService
 
 if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp")
 {


### PR DESCRIPTION


## Description

When stop-calico.ps1 is called from uninstall.ps1 we have to also pass
in the ExceptUpgradeService param to stop-calico.ps1
Otherwise the calico-upgrade service is stopped.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
